### PR TITLE
add volume size to aws cft

### DIFF
--- a/deployments/workspaces/platform/aws/cloud-formation-template/workspaces.yaml
+++ b/deployments/workspaces/platform/aws/cloud-formation-template/workspaces.yaml
@@ -9,6 +9,7 @@ Metadata:
           - WorkspacesName
           - InstanceType
           - VolumeSize
+          - TerminationProtection
       - Label:
           default: "Workspaces connection"
         Parameters:
@@ -66,9 +67,17 @@ Parameters:
     ConstraintDescription: Size in GB, between 10 and 1000.
     Description: port to access the workspaces service api.
     Type: Number
-    Default: 10
-    MinValue: 10
+    Default: 20
+    MinValue: 8
     MaxValue: 1000
+
+  TerminationProtection:
+    Description: Enable instance termination protection.
+    Type: String
+    AllowedValues:
+      - true
+      - false
+    Default: false
 
   InstanceType:
     AllowedValues:
@@ -195,7 +204,7 @@ Resources:
                 ensureRunning: "true"
     Properties:
       BlockDeviceMappings:
-        - DeviceName: /dev/sda1
+        - DeviceName: /dev/xvda
           Ebs:
             VolumeSize: !Ref VolumeSize
             Encrypted: true
@@ -203,7 +212,7 @@ Resources:
       ImageId: !Ref LatestAmiId
       InstanceType: !Ref InstanceType
       KeyName: !Ref KeyName
-      DisableApiTermination: true
+      DisableApiTermination: !Ref TerminationProtection
       SecurityGroupIds: [!GetAtt WorkspacesSecurityGroup.GroupId] 
       IamInstanceProfile: !Ref WorkspacesInstanceProfile
       UserData:

--- a/deployments/workspaces/platform/aws/cloud-formation-template/workspaces.yaml
+++ b/deployments/workspaces/platform/aws/cloud-formation-template/workspaces.yaml
@@ -8,6 +8,7 @@ Metadata:
         Parameters:
           - WorkspacesName
           - InstanceType
+          - VolumeSize
       - Label:
           default: "Workspaces connection"
         Parameters:
@@ -60,6 +61,14 @@ Parameters:
     Type: String
     Default: latest
     Description: Which version of workspaces to deploy, uses container version tags, defaults to "latest"
+
+  VolumeSize:
+    ConstraintDescription: Size in GB, between 10 and 1000.
+    Description: port to access the workspaces service api.
+    Type: Number
+    Default: 10
+    MinValue: 10
+    MaxValue: 1000
 
   InstanceType:
     AllowedValues:
@@ -188,6 +197,7 @@ Resources:
       BlockDeviceMappings:
         - DeviceName: /dev/sda1
           Ebs:
+            VolumeSize: !Ref VolumeSize
             Encrypted: true
       SubnetId: !Ref Subnet
       ImageId: !Ref LatestAmiId


### PR DESCRIPTION
Enabling EBS encryption on WS AWS CFT requires also setting volume size