### PR TITLE
add jupyter client to azure in terraform

### DIFF
--- a/deployments/jupyter/platform/azure/terraform/data.tf
+++ b/deployments/jupyter/platform/azure/terraform/data.tf
@@ -1,0 +1,61 @@
+data "azurerm_client_config" "this" {}
+data "azurerm_subscription" "this" {}
+
+locals {
+  image_publisher = "Canonical"
+  image_offer     = "0001-com-ubuntu-server-jammy"
+  image_sku       = "22_04-lts-gen2"
+  ssh_enabled     = var.ssh_enabled ? "Allow" : "Deny"
+}
+
+data "azurerm_ssh_public_key" "this" {
+  name                = var.key_name
+  resource_group_name = data.azurerm_resource_group.this.name
+}
+
+data "azurerm_platform_image" "this" {
+  location  = data.azurerm_resource_group.this.location
+  publisher = local.image_publisher
+  offer     = local.image_offer
+  sku       = local.image_sku
+}
+
+data "azurerm_resource_group" "this" {
+  name = var.resource_group_name
+}
+
+data "azurerm_virtual_network" "this" {
+  name                = var.network_name
+  resource_group_name = data.azurerm_resource_group.this.name
+}
+
+data "azurerm_subnet" "this" {
+  name                 = var.subnet_name
+  virtual_network_name = data.azurerm_virtual_network.this.name
+  resource_group_name  = data.azurerm_resource_group.this.name
+}
+
+data "cloudinit_config" "this" {
+  gzip          = true
+  base64_encode = true
+
+  part {
+    content_type = "text/cloud-config"
+    content = templatefile("${path.module}/templates/cloudinit.yaml.tftpl", {
+      jupyter_service : base64encode(templatefile("${path.module}/templates/jupyter.service.tftpl", {
+        jupyter_registry : var.jupyter_registry
+        jupyter_repository : var.jupyter_repository
+        jupyter_version : var.jupyter_version
+        jupyter_token : random_uuid.jupyter_token.result
+        http_port : var.http_port
+      }))
+    })
+  }
+}
+
+data "azurerm_public_ip" "this" {
+  name                = azurerm_public_ip.this.name
+  resource_group_name = data.azurerm_resource_group.this.name
+  depends_on          = [azurerm_virtual_machine.this]
+}
+

--- a/deployments/jupyter/platform/azure/terraform/firewalls.tf
+++ b/deployments/jupyter/platform/azure/terraform/firewalls.tf
@@ -1,0 +1,36 @@
+resource "azurerm_network_security_group" "this" {
+  name                = join("-", [var.jupyter_name, "access"])
+  resource_group_name = data.azurerm_resource_group.this.name
+  location            = data.azurerm_resource_group.this.location
+  tags                = var.tags
+}
+
+resource "azurerm_network_security_rule" "ssh" {
+  name                         = "${local.ssh_enabled}_SSH"
+  description                  = "${local.ssh_enabled} SSH"
+  priority                     = 700
+  direction                    = "Inbound"
+  access                       = local.ssh_enabled
+  protocol                     = "Tcp"
+  source_port_range            = "*"
+  destination_port_range       = "22"
+  source_address_prefixes      = var.access_cidrs
+  destination_address_prefixes = var.egress_cidrs
+  resource_group_name          = data.azurerm_resource_group.this.name
+  network_security_group_name  = azurerm_network_security_group.this.name
+}
+
+resource "azurerm_network_security_rule" "http" {
+  name                         = "Allow_HTTP"
+  description                  = "Allow HTTP"
+  priority                     = 701
+  direction                    = "Inbound"
+  access                       = "Allow"
+  protocol                     = "Tcp"
+  source_port_range            = "*"
+  destination_port_range       = var.http_port
+  source_address_prefixes      = var.access_cidrs
+  destination_address_prefixes = var.egress_cidrs
+  resource_group_name          = data.azurerm_resource_group.this.name
+  network_security_group_name  = azurerm_network_security_group.this.name
+}

--- a/deployments/jupyter/platform/azure/terraform/main.tf
+++ b/deployments/jupyter/platform/azure/terraform/main.tf
@@ -1,0 +1,27 @@
+terraform {
+
+  # override at init if needed
+  backend "local" {}
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "<=3.50.0"
+    }
+    cloudinit = {
+      source  = "hashicorp/cloudinit"
+      version = "<=2.2.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    virtual_machine {
+      delete_os_disk_on_deletion = true
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}

--- a/deployments/jupyter/platform/azure/terraform/network/network.tf
+++ b/deployments/jupyter/platform/azure/terraform/network/network.tf
@@ -1,0 +1,69 @@
+terraform {
+
+  # override at init if needed
+  backend "local" {}
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "<=3.50.0"
+    }
+    cloudinit = {
+      source  = "hashicorp/cloudinit"
+      version = "<=2.2.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    virtual_machine {
+      delete_os_disk_on_deletion = true
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+    key_vault {
+      purge_soft_delete_on_destroy    = true
+      recover_soft_deleted_key_vaults = false
+    }
+  }
+}
+
+
+resource "azurerm_resource_group" "this" {
+  name     = var.resource_group_name
+  location = var.region
+}
+
+resource "azurerm_virtual_network" "this" {
+  name                = var.network_name
+  address_space       = [var.network_cidr]
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  lifecycle {
+    ignore_changes = [
+      tags["CreateDate"],
+      tags["Owner"]
+    ]
+  }
+}
+
+resource "azurerm_subnet" "this" {
+  name                 = var.subnet_name
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = [var.subnet_cidr]
+}
+
+output "resource_group" {
+  value = azurerm_resource_group.this
+}
+
+output "network" {
+  value = azurerm_virtual_network.this
+}
+
+output "subnet" {
+  value = azurerm_subnet.this
+}

--- a/deployments/jupyter/platform/azure/terraform/network/variables.tf
+++ b/deployments/jupyter/platform/azure/terraform/network/variables.tf
@@ -1,0 +1,25 @@
+variable "resource_group_name" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "network_name" {
+  type = string
+}
+
+variable "subnet_name" {
+  type = string
+}
+
+variable "network_cidr" {
+  type    = string
+  default = "10.1.0.0/16"
+}
+
+variable "subnet_cidr" {
+  type    = string
+  default = "10.1.0.0/24"
+}

--- a/deployments/jupyter/platform/azure/terraform/outputs.tf
+++ b/deployments/jupyter/platform/azure/terraform/outputs.tf
@@ -1,0 +1,11 @@
+output "public_ip_jupyter" {
+  value = data.azurerm_public_ip.this.ip_address
+}
+
+output "http_access_jupyter" {
+  value = "http://${data.azurerm_public_ip.this.ip_address}:${var.http_port}?token=${random_uuid.jupyter_token.result}"
+}
+
+output "http_access_jupyter" {
+  value = "http://${data.azurerm_public_ip.this.ip_address}:${var.http_port}?token=${random_uuid.jupyter_token.result}"
+}

--- a/deployments/jupyter/platform/azure/terraform/resources.tf
+++ b/deployments/jupyter/platform/azure/terraform/resources.tf
@@ -1,0 +1,106 @@
+resource "azurerm_public_ip" "this" {
+  name                = join("-", [var.jupyter_name, "public-ip"])
+  location            = data.azurerm_resource_group.this.location
+  resource_group_name = data.azurerm_resource_group.this.name
+  allocation_method   = "Dynamic"
+  lifecycle {
+    ignore_changes = [
+      tags["CreateDate"],
+      tags["Owner"]
+    ]
+  }
+}
+
+resource "azurerm_network_interface" "this" {
+  name                = join("-", [var.jupyter_name, "nic"])
+  location            = data.azurerm_resource_group.this.location
+  resource_group_name = data.azurerm_resource_group.this.name
+
+  ip_configuration {
+    name                          = join("-", [var.jupyter_name, "nic"])
+    subnet_id                     = data.azurerm_subnet.this.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.this.id
+  }
+  lifecycle {
+    ignore_changes = [
+      tags["CreateDate"],
+      tags["Owner"]
+    ]
+  }
+}
+
+resource "azurerm_network_interface_security_group_association" "this" {
+  network_interface_id      = azurerm_network_interface.this.id
+  network_security_group_id = azurerm_network_security_group.this.id
+}
+
+resource "azurerm_virtual_machine" "this" {
+  name                  = var.jupyter_name
+  location              = data.azurerm_resource_group.this.location
+  resource_group_name   = data.azurerm_resource_group.this.name
+  network_interface_ids = [azurerm_network_interface.this.id]
+  vm_size               = var.instance_type
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
+  storage_image_reference {
+    publisher = data.azurerm_platform_image.this.publisher
+    offer     = data.azurerm_platform_image.this.offer
+    sku       = data.azurerm_platform_image.this.sku
+    version   = data.azurerm_platform_image.this.version
+  }
+
+  storage_os_disk {
+    name              = join("-", [var.jupyter_name, "disk"])
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = var.disk_type
+    disk_size_gb      = var.disk_size
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  os_profile {
+    computer_name  = var.jupyter_name
+    admin_username = "azureuser"
+    custom_data    = data.cloudinit_config.this.rendered
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = true
+    ssh_keys {
+      key_data = data.azurerm_ssh_public_key.this.public_key
+      path     = "/home/azureuser/.ssh/authorized_keys"
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      os_profile,
+      tags["CreateDate"],
+      tags["Owner"]
+    ]
+  }
+
+  tags = var.tags
+
+  depends_on = [
+    azurerm_network_interface_security_group_association.this
+  ]
+}
+
+resource "azurerm_virtual_machine_extension" "this" {
+  name                       = join("-", [var.jupyter_name, "Docker", "Extension"])
+  virtual_machine_id         = azurerm_virtual_machine.this.id
+  publisher                  = "Microsoft.Azure.Extensions"
+  type                       = "DockerExtension"
+  type_handler_version       = "1.1"
+  auto_upgrade_minor_version = true
+  tags                       = var.tags
+}
+
+resource "random_uuid" "jupyter_token" {}

--- a/deployments/jupyter/platform/azure/terraform/templates/cloudinit.yaml.tftpl
+++ b/deployments/jupyter/platform/azure/terraform/templates/cloudinit.yaml.tftpl
@@ -1,0 +1,13 @@
+#cloud-config
+write_files:
+- encoding: b64
+  content: "${ jupyter_service }"
+  owner: root:root
+  path: /usr/lib/systemd/system/jupyter.service
+  permissions: '0640'
+
+runcmd:
+- while [ $(systemctl status docker | grep "active (running)" | wc -l) -lt 1 ]; do sleep 5; done
+- sleep 60
+- systemctl enable jupyter.service
+- systemctl start jupyter.service

--- a/deployments/jupyter/platform/azure/terraform/templates/jupyter.service.tftpl
+++ b/deployments/jupyter/platform/azure/terraform/templates/jupyter.service.tftpl
@@ -1,0 +1,25 @@
+[Unit]
+Description=jupyter
+After=docker.service
+Requires=docker.service
+StartLimitInterval=200
+StartLimitBurst=10
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+RestartSec=2
+ExecStartPre=-/usr/bin/mkdir -p /etc/td
+ExecStartPre=-/usr/bin/docker exec %n stop || true
+ExecStartPre=-/usr/bin/docker rm %n || true
+ExecStartPre=/usr/bin/docker pull ${ jupyter_registry }/${ jupyter_repository }:${ jupyter_version }
+
+ExecStart=/usr/bin/docker run \
+    -e accept_license="Y" \
+    -e JUPYTER_TOKEN="${ jupyter_token}" \
+    -v /etc/td:/etc/td \
+    -p ${ http_port }:8888 \
+    --rm --name %n ${ jupyter_registry }/${ jupyter_repository }:${ jupyter_version }
+
+[Install]
+WantedBy=multi-user.target

--- a/deployments/jupyter/platform/azure/terraform/variables.tf
+++ b/deployments/jupyter/platform/azure/terraform/variables.tf
@@ -1,0 +1,78 @@
+variable "region" {
+  type = string
+}
+
+variable "resource_group_name" {
+  type = string
+}
+
+variable "network_name" {
+  type = string
+}
+
+variable "subnet_name" {
+  type = string
+}
+
+variable "instance_type" {
+  type    = string
+  default = "Standard_B2s"
+}
+
+variable "key_name" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "jupyter_name" {
+  type    = string
+  default = "jupyter"
+}
+
+variable "jupyter_registry" {
+  type    = string
+  default = "teradata"
+}
+
+variable "jupyter_repository" {
+  type    = string
+  default = "regulus-jupyter"
+}
+
+variable "jupyter_version" {
+  type    = string
+  default = "latest"
+}
+
+variable "ssh_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "access_cidrs" {
+  type    = list(string)
+}
+
+variable "egress_cidrs" {
+  type    = list(string)
+  default = ["0.0.0.0/0"]
+}
+
+variable "http_port" {
+  type    = number
+  default = 8888
+}
+
+variable "disk_type" {
+  type    = string
+  default = "Standard_LRS"
+}
+
+variable "disk_size" {
+  type    = number
+  default = 30
+}

--- a/deployments/workspaces/platform/azure/terraform/outputs.tf
+++ b/deployments/workspaces/platform/azure/terraform/outputs.tf
@@ -1,3 +1,15 @@
-output "public_ips_master" {
+output "public_ip_workspaces" {
   value = data.azurerm_public_ip.this.ip_address
+}
+
+output "http_access_workspaces" {
+  value = "http://${data.azurerm_public_ip.this.ip_address}:${var.http_port}"
+}
+
+output "grpc_access_from_public" {
+  value = "${data.azurerm_public_ip.this.ip_address}:${var.grpc_port}"
+}
+
+output "grpc_access_from_private" {
+  value = "${azurerm_network_interface.this.private_ip_address}:${var.grpc_port}"
 }


### PR DESCRIPTION
Adds the first of the Jupyter client deploys to Azure via Terraform. 
Uses the same setup as workspaces, i.e. it just runs the Jupyter container via systemd and installs on a default Azure image.

The instance takes some time to set up as the Jupyter Container is rather large, and it displays the auth token in the terraform output. As such, it should be treated as a demo or ephemeral environment, not a hardened enterprise service 