### PR TITLE
Feat/jupyter client aws

### DIFF
--- a/.github/workflows/tf-docs.yml
+++ b/.github/workflows/tf-docs.yml
@@ -1,0 +1,29 @@
+name: Generate terraform docs
+on:
+  - pull_request
+
+jobs:
+  docs:
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - aws
+          - azure
+        application:
+          - workspaces
+          - jupyter
+
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        ref: ${{ github.event.pull_request.head.ref }}
+
+    - name: Render terraform docs and push changes back to PR
+      uses: terraform-docs/gh-actions@main
+      with:
+        working-dir: ./deployments/${{ matrix.application }}/platform/${{ matrix.platform }}/terraform
+        output-file: README.md
+        output-method: inject
+        git-push: "true"

--- a/deployments/jupyter/platform/aws/cloud-formation-template/jupyter.yaml
+++ b/deployments/jupyter/platform/aws/cloud-formation-template/jupyter.yaml
@@ -1,0 +1,252 @@
+AWSTemplateFormatVersion: '2010-09-09'
+Metadata:
+  License: TODO
+  AWS::CloudFormation::Interface:
+    ParameterGroups:
+      - Label:
+          default: "jupyter"
+        Parameters:
+          - jupyterName
+          - InstanceType
+          - VolumeSize
+          - TerminationProtection
+          - JupyterToken
+      - Label:
+          default: "jupyter connection"
+        Parameters:
+          - Subnet
+          - KeyName
+          - AccessCIDR
+
+Description: >-
+  AWS CloudFormation Template jupyter: a jupyter instance configured with the regulus kernel.
+
+Parameters:
+  LatestAmiId:
+    Type: 'AWS::SSM::Parameter::Value<AWS::EC2::Image::Id>'
+    Default: '/aws/service/ami-amazon-linux-latest/amzn2-ami-hvm-x86_64-gp2'
+
+  jupyterName:
+    AllowedPattern: '^[a-zA-Z][a-zA-Z0-9-]*'
+    ConstraintDescription: must begin with a letter and contain only alphanumeric
+      characters.
+    Default: jupyter
+    Description: The jupyter service instance name
+    MaxLength: '32'
+    MinLength: '1'
+    Type: String
+
+  Subnet:
+    ConstraintDescription: must be the name of an existing subnet.
+    Description: Subnetwork to deploy the jupyter service to.
+    Type: AWS::EC2::Subnet::Id
+
+  HttpPort:
+    ConstraintDescription: must be a valid ununsed port between 0 and 65535.
+    Description: port to access the jupyter service ui.
+    Type: Number
+    Default: 8888
+    MinValue: 0
+    MaxValue: 65535
+
+  Version:
+    Type: String
+    Default: latest
+    Description: Which version of jupyter to deploy, uses container version tags, defaults to "latest"
+
+  JupyterToken:
+    Type: String
+    NoEcho: true
+    Description: The token or password equivalent used to access Jupyter.
+
+  VolumeSize:
+    ConstraintDescription: Size in GB, between 10 and 1000.
+    Description: port to access the jupyter service api.
+    Type: Number
+    Default: 20
+    MinValue: 8
+    MaxValue: 1000
+
+  TerminationProtection:
+    Description: Enable instance termination protection.
+    Type: String
+    AllowedValues:
+      - true
+      - false
+    Default: false
+
+  InstanceType:
+    AllowedValues:
+    - t2.nano
+    - t2.micro
+    - t2.small
+    - t2.medium
+    - t2.large
+    - t3.nano
+    - t3.micro
+    - t3.small
+    - t3.medium
+    - t3.large
+    - m3.medium
+    - m3.large
+    - m3.xlarge
+    - m3.2xlarge
+    - m4.large
+    - m4.xlarge
+    - m4.2xlarge
+    - m4.4xlarge
+    - m4.10xlarge
+    - c3.large
+    - c3.xlarge
+    - c3.2xlarge
+    - c3.4xlarge
+    - c3.8xlarge
+    - c4.large
+    - c4.xlarge
+    - c4.2xlarge
+    - c4.4xlarge
+    - c4.8xlarge
+    - r3.large
+    - r3.xlarge
+    - r3.2xlarge
+    - r3.4xlarge
+    - r3.8xlarge
+    - i2.xlarge
+    - i2.2xlarge
+    - i2.4xlarge
+    - i2.8xlarge
+    ConstraintDescription: must be a valid EC2 instance type.
+    Default: t2.micro
+    Description: jupyter EC2 instance type
+    Type: String
+
+  KeyName:
+    ConstraintDescription: must be the name of an existing EC2 KeyPair.
+    Description: Name of an existing EC2 KeyPair to enable SSH access to the instances
+    Type: AWS::EC2::KeyPair::KeyName
+
+  AccessCIDR:
+    AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\/(\d{1,2})
+    ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
+    Default: 0.0.0.0/0
+    Description: The IP address range that can be used to communicate with the jupyter instance.
+    MaxLength: '18'
+    MinLength: '9'
+    Type: String
+
+Resources:
+
+  jupyterServer:
+    Type: AWS::EC2::Instance
+    CreationPolicy:
+      ResourceSignal:
+        Timeout: PT15M
+    Metadata:
+      AWS::CloudFormation::Init:
+        configSets:
+          jupyter_install:
+          - install_docker
+          - configure_jupyter_service
+          - start_jupyter_service
+        install_docker:
+          commands:
+            install_docker:
+              command: !Sub |
+                #!/bin/bash -xe
+                amazon-linux-extras install docker -y
+                amazon-linux-extras enable docker
+          services:
+            systemd:
+              docker:
+                enabled: "true"
+                ensureRunning: "true"
+        configure_jupyter_service:
+          files:
+            /usr/lib/systemd/system/jupyter.service:
+              content: !Sub |
+                [Unit]
+                Description=jupyter
+                After=docker.service
+                Requires=docker.service
+                StartLimitInterval=200
+                StartLimitBurst=10
+
+                [Service]
+                TimeoutStartSec=0
+                Restart=always
+                RestartSec=2
+                ExecStartPre=-/usr/bin/mkdir -p /etc/td
+                ExecStartPre=-/usr/bin/docker exec %n stop || true
+                ExecStartPre=-/usr/bin/docker rm %n || true
+                ExecStartPre=/usr/bin/docker pull teradata/regulus-jupyter:${ Version }
+                ExecStart=/usr/bin/docker run \
+                    -e accept_license=Y \
+                    -e JUPYTER_TOKEN=${ JupyterToken } \
+                    -v /etc/td:/home/jovyan/JupyterLabRoot/userdata \
+                    -p ${ HttpPort }:8888 \
+                    --rm --name %n teradata/regulus-jupyter:${ Version }
+
+                [Install]
+                WantedBy=multi-user.target
+              group: root
+              mode: '000400'
+              owner: root
+        start_jupyter_service:
+          services:
+            systemd:
+              jupyter:
+                enabled: "true"
+                ensureRunning: "true"
+    Properties:
+      BlockDeviceMappings:
+        - DeviceName: /dev/xvda
+          Ebs:
+            VolumeSize: !Ref VolumeSize
+            Encrypted: true
+      SubnetId: !Ref Subnet
+      ImageId: !Ref LatestAmiId
+      InstanceType: !Ref InstanceType
+      KeyName: !Ref KeyName
+      DisableApiTermination: !Ref TerminationProtection
+      SecurityGroupIds: [!GetAtt jupyterSecurityGroup.GroupId] 
+      UserData:
+        Fn::Base64: !Sub |
+           #!/bin/bash -xe
+           yum update -y
+           yum update -y aws-cfn-bootstrap
+           /opt/aws/bin/cfn-init -v --stack ${AWS::StackId} --resource jupyterServer --configsets jupyter_install --region ${AWS::Region}
+           /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource jupyterServer --region ${AWS::Region}
+
+  jupyterSecurityGroup:
+    Type: AWS::EC2::SecurityGroup
+    Properties:
+      GroupDescription: "Enable access to jupyter server over http, grpc, and ssh"
+      SecurityGroupIngress:
+      - CidrIp: !Ref AccessCIDR
+        FromPort: !Ref HttpPort
+        IpProtocol: tcp
+        ToPort: !Ref HttpPort
+      - CidrIp: !Ref AccessCIDR
+        FromPort: 22
+        IpProtocol: tcp
+        ToPort: 22
+
+Outputs:
+  PublicIP:
+    Description: EC2 public IP
+    Value: !GetAtt jupyterServer.PublicIp
+  PrivateIP:
+    Description: EC2 private IP
+    Value: !GetAtt jupyterServer.PrivateIp
+  PublicHttpAccess:
+    Description: Teradata jupyter Server
+    Value: !Sub "http://${jupyterServer.PublicDnsName}:${ HttpPort }?token=${ JupyterToken }"
+  PrivateHttpAccess:
+    Description: Teradata jupyter Server
+    Value: !Sub "http://${jupyterServer.PrivateDnsName}:${ HttpPort }?token=${ JupyterToken }"
+  SecurityGroup:
+    Description: jupyter Security Group
+    Value: !GetAtt jupyterSecurityGroup.GroupId
+  SSHConeection:
+    Description: jupyter ssh connnection string
+    Value: !Sub "ssh ec2-user@${ jupyterServer.PublicIp }"

--- a/deployments/jupyter/platform/aws/terraform/README.md
+++ b/deployments/jupyter/platform/aws/terraform/README.md
@@ -1,0 +1,62 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.36.1 |
+| <a name="requirement_cloudinit"></a> [cloudinit](#requirement\_cloudinit) | ~> 2.2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.36.1 |
+| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | ~> 2.2.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
+| [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
+| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [random_uuid.jupyter_token](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
+| [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_subnet.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
+| [cloudinit_config.this](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_access_cidrs"></a> [access\_cidrs](#input\_access\_cidrs) | n/a | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_access_security_groups"></a> [access\_security\_groups](#input\_access\_security\_groups) | n/a | `list(string)` | `[]` | no |
+| <a name="input_egress_cidrs"></a> [egress\_cidrs](#input\_egress\_cidrs) | n/a | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_http_port"></a> [http\_port](#input\_http\_port) | n/a | `number` | `8888` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | n/a | `string` | `"t3.large"` | no |
+| <a name="input_jupyter_name"></a> [jupyter\_name](#input\_jupyter\_name) | n/a | `string` | `"jupyter"` | no |
+| <a name="input_jupyter_registry"></a> [jupyter\_registry](#input\_jupyter\_registry) | n/a | `string` | `"teradata"` | no |
+| <a name="input_jupyter_repository"></a> [jupyter\_repository](#input\_jupyter\_repository) | n/a | `string` | `"regulus-jupyter"` | no |
+| <a name="input_jupyter_version"></a> [jupyter\_version](#input\_jupyter\_version) | n/a | `string` | `"latest"` | no |
+| <a name="input_key_name"></a> [key\_name](#input\_key\_name) | name of existing ssh key to enable access to jupyter server | `string` | `null` | no |
+| <a name="input_monitoring_enabled"></a> [monitoring\_enabled](#input\_monitoring\_enabled) | n/a | `bool` | `false` | no |
+| <a name="input_region"></a> [region](#input\_region) | n/a | `string` | n/a | yes |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | n/a | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_private_http_accessr"></a> [private\_http\_accessr](#output\_private\_http\_accessr) | n/a |
+| <a name="output_private_ip"></a> [private\_ip](#output\_private\_ip) | n/a |
+| <a name="output_public_http_access"></a> [public\_http\_access](#output\_public\_http\_access) | n/a |
+| <a name="output_public_ip"></a> [public\_ip](#output\_public\_ip) | n/a |
+| <a name="output_security_group"></a> [security\_group](#output\_security\_group) | n/a |
+| <a name="output_ssh_connection"></a> [ssh\_connection](#output\_ssh\_connection) | n/a |
+<!-- END_TF_DOCS -->

--- a/deployments/jupyter/platform/aws/terraform/data.tf
+++ b/deployments/jupyter/platform/aws/terraform/data.tf
@@ -1,0 +1,35 @@
+data "aws_subnet" "this" {
+  id = var.subnet_id
+}
+
+data "aws_ami" "this" {
+  most_recent = true
+
+  filter {
+    name   = "owner-alias"
+    values = ["amazon"]
+  }
+
+  filter {
+    name   = "name"
+    values = ["amzn2-ami-hvm-*-x86_64-ebs"]
+  }
+}
+
+data "cloudinit_config" "this" {
+  gzip          = true
+  base64_encode = true
+
+  part {
+    content_type = "text/cloud-config"
+    content = templatefile("${path.module}/templates/cloudinit.yaml.tftpl", {
+      jupyter_service : base64encode(templatefile("${path.module}/templates/jupyter.service.tftpl", {
+        jupyter_registry : var.jupyter_registry
+        jupyter_repository : var.jupyter_repository
+        jupyter_version : var.jupyter_version
+        jupyter_token : random_uuid.jupyter_token.result
+        http_port : var.http_port
+      }))
+    })
+  }
+}

--- a/deployments/jupyter/platform/aws/terraform/firewalls.tf
+++ b/deployments/jupyter/platform/aws/terraform/firewalls.tf
@@ -7,6 +7,7 @@ resource "aws_security_group" "this" {
     to_port     = 0
     protocol    = -1
     cidr_blocks = var.egress_cidrs
+    security_groups = var.access_security_groups
   }
 
   ingress {
@@ -25,15 +26,7 @@ resource "aws_security_group" "this" {
     security_groups = var.access_security_groups
   }
 
-  ingress {
-    from_port   = var.grpc_port
-    to_port     = var.grpc_port
-    protocol    = "tcp"
-    cidr_blocks = var.access_cidrs
-    security_groups = var.access_security_groups
-  }
-
   tags = {
-    Name = join("-", [var.workspaces_name, "access"])
+    Name = join("-", [var.jupyter_name, "access"])
   }
 }

--- a/deployments/jupyter/platform/aws/terraform/main.tf
+++ b/deployments/jupyter/platform/aws/terraform/main.tf
@@ -1,0 +1,20 @@
+terraform {
+
+  # override at init if needed
+  backend "local" {}
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 4.36.1"
+    }
+    cloudinit = {
+      source  = "hashicorp/cloudinit"
+      version = "~> 2.2.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.region
+}

--- a/deployments/jupyter/platform/aws/terraform/outputs.tf
+++ b/deployments/jupyter/platform/aws/terraform/outputs.tf
@@ -1,0 +1,23 @@
+output "public_ip" {
+  value = aws_instance.this.public_ip
+}
+
+output "private_ip" {
+  value = aws_instance.this.private_ip
+}
+
+output "public_http_access" {
+  value = "http://${aws_instance.this.public_ip}:${var.http_port}?token=${random_uuid.jupyter_token.result}"
+}
+
+output "private_http_accessr" {
+  value = "http://${aws_instance.this.private_ip}:${var.http_port}?token=${random_uuid.jupyter_token.result}"
+}
+
+output "security_group" {
+  value = aws_security_group.this.id
+}
+
+output "ssh_connection" {
+  value = "ssh ec2-user@${aws_instance.this.public_ip}"
+}

--- a/deployments/jupyter/platform/aws/terraform/resources.tf
+++ b/deployments/jupyter/platform/aws/terraform/resources.tf
@@ -1,5 +1,5 @@
 resource "aws_launch_template" "this" {
-  name_prefix   = var.workspaces_name
+  name_prefix   = var.jupyter_name
   image_id      = data.aws_ami.this.id
   instance_type = var.instance_type
 
@@ -16,14 +16,14 @@ resource "aws_launch_template" "this" {
   }
 
   tags = merge({
-    Name = var.workspaces_name
+    Name = var.jupyter_name
     },
     var.tags
   )
 
   tag_specifications {
     resource_type = "volume"
-    tags          = merge({ Name = join("-", [var.workspaces_name, "workspaces-volume"]) }, var.tags)
+    tags          = merge({ Name = join("-", [var.jupyter_name, "jupyter-volume"]) }, var.tags)
   }
 
   metadata_options {
@@ -32,9 +32,6 @@ resource "aws_launch_template" "this" {
     http_tokens            = "required"
   }
 
-  iam_instance_profile {
-    arn = aws_iam_instance_profile.this.arn
-  }
 }
 
 resource "aws_instance" "this" {
@@ -49,15 +46,15 @@ resource "aws_instance" "this" {
 
   root_block_device {
     delete_on_termination = true
-    volume_size           = var.volume_size
+    volume_size           = 20
     volume_type           = "gp2"
     encrypted             = true
   }
 
   tags = {
-  Name = join("-", [var.workspaces_name, "workspaces"]) }
+  Name = join("-", [var.jupyter_name, "jupyter"]) }
 
-  disable_api_termination = var.termination_protection
+  disable_api_termination = true
 
   lifecycle {
     ignore_changes = [
@@ -68,3 +65,5 @@ resource "aws_instance" "this" {
     ]
   }
 }
+
+resource "random_uuid" "jupyter_token" {}

--- a/deployments/jupyter/platform/aws/terraform/templates/cloudinit.yaml.tftpl
+++ b/deployments/jupyter/platform/aws/terraform/templates/cloudinit.yaml.tftpl
@@ -1,0 +1,15 @@
+#cloud-config
+write_files:
+- encoding: b64
+  content: "${ jupyter_service }"
+  owner: root:root
+  path: /usr/lib/systemd/system/jupyter.service
+  permissions: '0640'
+
+runcmd:
+- amazon-linux-extras install docker -y
+- amazon-linux-extras enable docker
+- systemctl enable docker.service
+- systemctl start docker.service
+- systemctl enable jupyter.service
+- systemctl start jupyter.service

--- a/deployments/jupyter/platform/aws/terraform/templates/jupyter.service.tftpl
+++ b/deployments/jupyter/platform/aws/terraform/templates/jupyter.service.tftpl
@@ -1,0 +1,25 @@
+[Unit]
+Description=jupyter
+After=docker.service
+Requires=docker.service
+StartLimitInterval=200
+StartLimitBurst=10
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+RestartSec=2
+ExecStartPre=-/usr/bin/mkdir -p /etc/td
+ExecStartPre=-/usr/bin/docker exec %n stop || true
+ExecStartPre=-/usr/bin/docker rm %n || true
+ExecStartPre=/usr/bin/docker pull ${ jupyter_registry }/${ jupyter_repository }:${ jupyter_version }
+
+ExecStart=/usr/bin/docker run \
+    -e accept_license=Y \
+    -e JUPYTER_TOKEN=${ jupyter_token } \
+    -v /etc/td:/home/jovyan/JupyterLabRoot/userdata \
+    -p ${ http_port }:8888 \
+    --rm --name %n ${ jupyter_registry }/${ jupyter_repository }:${ jupyter_version }
+
+[Install]
+WantedBy=multi-user.target

--- a/deployments/jupyter/platform/aws/terraform/terraform.tfvars
+++ b/deployments/jupyter/platform/aws/terraform/terraform.tfvars
@@ -1,3 +1,4 @@
 # region = ""
 # subnet_id = ""
 # key_name = ""
+# access_cidrs ""

--- a/deployments/jupyter/platform/aws/terraform/variables.tf
+++ b/deployments/jupyter/platform/aws/terraform/variables.tf
@@ -11,18 +11,8 @@ variable "instance_type" {
   default = "t3.large"
 }
 
-variable "volume_size" {
-  type    = number
-  default = 20
-}
-
-variable "termination_protection" {
-  type    = bool
-  default = false
-}
-
 variable "key_name" {
-  description = "name of existing ssh key to enable access to workspaces server"
+  description = "name of existing ssh key to enable access to jupyter server"
   type        = string
   default     = null
 }
@@ -32,22 +22,22 @@ variable "tags" {
   default = {}
 }
 
-variable "workspaces_name" {
+variable "jupyter_name" {
   type    = string
-  default = "workspaces"
+  default = "jupyter"
 }
 
-variable "workspaces_registry" {
+variable "jupyter_registry" {
   type    = string
   default = "teradata"
 }
 
-variable "workspaces_repository" {
+variable "jupyter_repository" {
   type    = string
-  default = "regulus-workspaces"
+  default = "regulus-jupyter"
 }
 
-variable "workspaces_version" {
+variable "jupyter_version" {
   type    = string
   default = "latest"
 }
@@ -74,10 +64,5 @@ variable "monitoring_enabled" {
 
 variable "http_port" {
   type    = number
-  default = 3000
-}
-
-variable "grpc_port" {
-  type    = number
-  default = 3282
+  default = 8888
 }

--- a/deployments/jupyter/platform/azure/resource-manager-template/arm-template.json
+++ b/deployments/jupyter/platform/azure/resource-manager-template/arm-template.json
@@ -5,21 +5,21 @@
     "_generator": {
       "name": "bicep",
       "version": "0.18.4.5664",
-      "templateHash": "12911493323856216175"
+      "templateHash": "3802902211667631024"
     }
   },
   "parameters": {
-    "workspacesName": {
+    "jupyterName": {
       "type": "string",
-      "defaultValue": "workspaces",
+      "defaultValue": "jupyter",
       "metadata": {
-        "description": "Name for the workspaces service virtual machine."
+        "description": "Name for the jupyter service virtual machine."
       }
     },
     "adminUsername": {
       "type": "string",
       "metadata": {
-        "description": "Username for the workspaces service virtual machine."
+        "description": "Username for the jupyter service virtual machine."
       }
     },
     "sshPublicKey": {
@@ -28,9 +28,15 @@
         "description": "SSH public key value"
       }
     },
+    "jupyterToken": {
+      "type": "securestring",
+      "metadata": {
+        "description": "jupyter token value"
+      }
+    },
     "dnsLabelPrefix": {
       "type": "string",
-      "defaultValue": "[toLower(format('{0}-{1}', parameters('workspacesName'), uniqueString(resourceGroup().id)))]",
+      "defaultValue": "[toLower(format('{0}-{1}', parameters('jupyterName'), uniqueString(resourceGroup().id)))]",
       "metadata": {
         "description": "Unique DNS Name for the Public IP used to access the Virtual Machine."
       }
@@ -85,41 +91,27 @@
     "accessCidrs": {
       "type": "array",
       "metadata": {
-        "description": "The CIDR ranges that can be used to communicate with the workspaces instance."
+        "description": "The CIDR ranges that can be used to communicate with the jupyter instance."
       }
     },
     "httpPort": {
       "type": "string",
-      "defaultValue": "3000",
+      "defaultValue": "8888",
       "metadata": {
-        "description": "port to access the workspaces service UI."
-      }
-    },
-    "grpcPort": {
-      "type": "string",
-      "defaultValue": "3282",
-      "metadata": {
-        "description": "port to access the workspaces service api."
+        "description": "port to access the jupyter service UI."
       }
     },
     "sshAccess": {
       "type": "bool",
       "defaultValue": false,
       "metadata": {
-        "description": "allow access the workspaces ssh port from the access cidr."
-      }
-    },
-    "customRoleName": {
-      "type": "string",
-      "defaultValue": "",
-      "metadata": {
-        "description": "Custom Role Name."
+        "description": "allow access the jupyter ssh port from the access cidr."
       }
     }
   },
   "variables": {
-    "$fxv#0": "#cloud-config\nwrite_files:\n- encoding: b64\n  content: \"{0}\"\n  owner: root:root\n  path: /usr/lib/systemd/system/workspaces.service\n  permissions: '0640'\n\nruncmd:\n- while [ $(systemctl status docker | grep \"active (running)\" | wc -l) -lt 1 ]; do sleep 5; done\n- sleep 60\n- systemctl enable workspaces.service\n- systemctl start workspaces.service",
-    "$fxv#1": "[Unit]\nDescription=workspaces\nAfter=docker.service\nRequires=docker.service\nStartLimitInterval=200\nStartLimitBurst=10\n\n[Service]\nTimeoutStartSec=0\nRestart=always\nRestartSec=2\nExecStartPre=-/usr/bin/mkdir -p /etc/td\nExecStartPre=-/usr/bin/docker exec %n stop || true\nExecStartPre=-/usr/bin/docker rm %n || true\nExecStartPre=/usr/bin/docker pull {0}/{1}:{2}\n\nExecStart=/usr/bin/docker run \\\n    -e accept_license=Y \\\n    -e PLATFORM=azure \\\n    -e ARM_USE_MSI=true \\\n    -e ARM_SUBSCRIPTION_ID={5} \\\n    -e ARM_TENANT_ID={6} \\\n    -v /etc/td:/etc/td \\\n    -p {3}:3000 \\\n    -p {4}:3282 \\\n    --rm --name %n {0}/{1}:{2} workspaces serve -v\n\n[Install]\nWantedBy=multi-user.target",
+    "$fxv#0": "#cloud-config\nwrite_files:\n- encoding: b64\n  content: \"{0}\"\n  owner: root:root\n  path: /usr/lib/systemd/system/jupyter.service\n  permissions: '0640'\n\nruncmd:\n- while [ $(systemctl status docker | grep \"active (running)\" | wc -l) -lt 1 ]; do sleep 5; done\n- sleep 60\n- systemctl enable jupyter.service\n- systemctl start jupyter.service",
+    "$fxv#1": "[Unit]\nDescription=jupyter\nAfter=docker.service\nRequires=docker.service\nStartLimitInterval=200\nStartLimitBurst=10\n\n[Service]\nTimeoutStartSec=0\nRestart=always\nRestartSec=2\nExecStartPre=-/usr/bin/mkdir -p /etc/td\nExecStartPre=-/usr/bin/docker exec %n stop || true\nExecStartPre=-/usr/bin/docker rm %n || true\nExecStartPre=/usr/bin/docker pull {0}/{1}:{2}\n\nExecStart=/usr/bin/docker run \\\n    -e accept_license=Y \\\n    -e JUPYTER_TOKEN=${4} \\\n    -v /etc/td:/home/jovyan/JupyterLabRoot/userdata \\\n    -p {3}:8888 \\\n    --rm --name %n {0}/{1}:{2}\n\n[Install]\nWantedBy=multi-user.target",
     "imageReference": {
       "Ubuntu-1804": {
         "publisher": "Canonical",
@@ -140,8 +132,8 @@
         "version": "latest"
       }
     },
-    "publicIPAddressName": "[format('{0}PublicIP', parameters('workspacesName'))]",
-    "networkInterfaceName": "[format('{0}NetInt', parameters('workspacesName'))]",
+    "publicIPAddressName": "[format('{0}PublicIP', parameters('jupyterName'))]",
+    "networkInterfaceName": "[format('{0}NetInt', parameters('jupyterName'))]",
     "osDiskType": "Standard_LRS",
     "subnetAddressPrefix": "10.1.0.0/24",
     "addressPrefix": "10.1.0.0/16",
@@ -165,9 +157,9 @@
     "dockerExtensionPublisher": "Microsoft.Azure.Extensions",
     "dockerExtensionVersion": "1.1",
     "registry": "teradata",
-    "repository": "regulus-workspaces",
+    "repository": "regulus-jupyter",
     "version": "latest",
-    "cloudInitData": "[base64(format(variables('$fxv#0'), base64(format(variables('$fxv#1'), variables('registry'), variables('repository'), variables('version'), parameters('httpPort'), parameters('grpcPort'), subscription().subscriptionId, subscription().tenantId))))]"
+    "cloudInitData": "[base64(format(variables('$fxv#0'), base64(format(variables('$fxv#1'), variables('registry'), variables('repository'), variables('version'), parameters('httpPort'), parameters('jupyterToken')))))]"
   },
   "resources": [
     {
@@ -232,19 +224,6 @@
               "destinationAddressPrefix": "*",
               "destinationPortRange": "[parameters('httpPort')]"
             }
-          },
-          {
-            "name": "GRPC",
-            "properties": {
-              "priority": 702,
-              "protocol": "Tcp",
-              "access": "Allow",
-              "direction": "Inbound",
-              "sourceAddressPrefixes": "[parameters('accessCidrs')]",
-              "sourcePortRange": "*",
-              "destinationAddressPrefix": "*",
-              "destinationPortRange": "[parameters('grpcPort')]"
-            }
           }
         ]
       }
@@ -295,7 +274,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines",
       "apiVersion": "2023-03-01",
-      "name": "[parameters('workspacesName')]",
+      "name": "[parameters('jupyterName')]",
       "location": "[parameters('location')]",
       "identity": {
         "type": "SystemAssigned"
@@ -321,7 +300,7 @@
           ]
         },
         "osProfile": {
-          "computerName": "[parameters('workspacesName')]",
+          "computerName": "[parameters('jupyterName')]",
           "adminUsername": "[parameters('adminUsername')]",
           "linuxConfiguration": "[variables('linuxConfiguration')]"
         },
@@ -342,7 +321,7 @@
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2022-03-01",
-      "name": "[format('{0}/{1}', parameters('workspacesName'), variables('trustedExtensionName'))]",
+      "name": "[format('{0}/{1}', parameters('jupyterName'), variables('trustedExtensionName'))]",
       "location": "[parameters('location')]",
       "properties": {
         "publisher": "[variables('trustedExtensionPublisher')]",
@@ -359,13 +338,13 @@
         }
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Compute/virtualMachines', parameters('workspacesName'))]"
+        "[resourceId('Microsoft.Compute/virtualMachines', parameters('jupyterName'))]"
       ]
     },
     {
       "type": "Microsoft.Compute/virtualMachines/extensions",
       "apiVersion": "2023-03-01",
-      "name": "[format('{0}/{1}', parameters('workspacesName'), variables('dockerExtensionName'))]",
+      "name": "[format('{0}/{1}', parameters('jupyterName'), variables('dockerExtensionName'))]",
       "location": "[parameters('location')]",
       "properties": {
         "publisher": "[variables('dockerExtensionPublisher')]",
@@ -374,95 +353,8 @@
         "autoUpgradeMinorVersion": true
       },
       "dependsOn": [
-        "[resourceId('Microsoft.Compute/virtualMachines', parameters('workspacesName'))]"
+        "[resourceId('Microsoft.Compute/virtualMachines', parameters('jupyterName'))]"
       ]
-    },
-    {
-      "condition": "[not(equals(parameters('customRoleName'), ''))]",
-      "type": "Microsoft.Authorization/roleAssignments",
-      "apiVersion": "2022-04-01",
-      "name": "[guid(subscription().id, resourceId('Microsoft.Compute/virtualMachines', parameters('workspacesName')), resourceId('Microsoft.Authorization/roleDefinitions', parameters('customRoleName')))]",
-      "properties": {
-        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', parameters('customRoleName'))]",
-        "principalId": "[reference(resourceId('Microsoft.Compute/virtualMachines', parameters('workspacesName')), '2023-03-01', 'full').identity.principalId]"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Compute/virtualMachines', parameters('workspacesName'))]"
-      ]
-    },
-    {
-      "condition": "[equals(parameters('customRoleName'), '')]",
-      "type": "Microsoft.Authorization/roleAssignments",
-      "apiVersion": "2022-04-01",
-      "name": "[guid(subscription().id, resourceId('Microsoft.Compute/virtualMachines', parameters('workspacesName')), resourceId('Microsoft.Authorization/roleDefinitions', format('{0}-custom-role', parameters('workspacesName'))))]",
-      "properties": {
-        "roleDefinitionId": "[resourceId('Microsoft.Authorization/roleDefinitions', format('{0}-custom-role', parameters('workspacesName')))]",
-        "principalId": "[reference(resourceId('Microsoft.Compute/virtualMachines', parameters('workspacesName')), '2023-03-01', 'full').identity.principalId]"
-      },
-      "dependsOn": [
-        "[resourceId('Microsoft.Authorization/roleDefinitions', format('{0}-custom-role', parameters('workspacesName')))]",
-        "[resourceId('Microsoft.Compute/virtualMachines', parameters('workspacesName'))]"
-      ]
-    },
-    {
-      "condition": "[equals(parameters('customRoleName'), '')]",
-      "type": "Microsoft.Authorization/roleDefinitions",
-      "apiVersion": "2022-04-01",
-      "name": "[format('{0}-custom-role', parameters('workspacesName'))]",
-      "properties": {
-        "roleName": "[format('Custom Role - Workspaces {0} Regulus Deployment Permissions', parameters('workspacesName'))]",
-        "description": "[format('Subscription level permissions for workspaces {0} to create regulus deployments', parameters('workspacesName'))]",
-        "type": "customRole",
-        "permissions": [
-          {
-            "actions": [
-              "Microsoft.Compute/disks/read",
-              "Microsoft.Compute/disks/write",
-              "Microsoft.Compute/disks/delete",
-              "Microsoft.Compute/sshPublicKeys/read",
-              "Microsoft.Compute/sshPublicKeys/write",
-              "Microsoft.Compute/sshPublicKeys/delete",
-              "Microsoft.Compute/virtualMachines/read",
-              "Microsoft.Compute/virtualMachines/write",
-              "Microsoft.Compute/virtualMachines/delete",
-              "Microsoft.KeyVault/vaults/read",
-              "Microsoft.KeyVault/vaults/write",
-              "Microsoft.KeyVault/vaults/delete",
-              "Microsoft.KeyVault/vaults/accessPolicies/write",
-              "Microsoft.KeyVault/locations/operationResults/read",
-              "Microsoft.KeyVault/locations/deletedVaults/purge/action",
-              "Microsoft.Network/virtualNetworks/read",
-              "Microsoft.Network/virtualNetworks/write",
-              "Microsoft.Network/virtualNetworks/delete",
-              "Microsoft.Network/virtualNetworks/subnets/read",
-              "Microsoft.Network/virtualNetworks/subnets/write",
-              "Microsoft.Network/virtualNetworks/subnets/delete",
-              "Microsoft.Network/virtualNetworks/subnets/join/action",
-              "Microsoft.Network/networkInterfaces/read",
-              "Microsoft.Network/networkInterfaces/write",
-              "Microsoft.Network/networkInterfaces/delete",
-              "Microsoft.Network/networkInterfaces/join/action",
-              "Microsoft.Network/networkSecurityGroups/read",
-              "Microsoft.Network/networkSecurityGroups/write",
-              "Microsoft.Network/networkSecurityGroups/delete",
-              "Microsoft.Network/networkSecurityGroups/securityRules/read",
-              "Microsoft.Network/networkSecurityGroups/securityRules/write",
-              "Microsoft.Network/networkSecurityGroups/securityRules/delete",
-              "Microsoft.Network/networkSecurityGroups/join/action",
-              "Microsoft.Network/publicIPAddresses/read",
-              "Microsoft.Network/publicIPAddresses/write",
-              "Microsoft.Network/publicIPAddresses/join/action",
-              "Microsoft.Network/publicIPAddresses/delete",
-              "Microsoft.Resources/subscriptions/resourcegroups/read",
-              "Microsoft.Resources/subscriptions/resourcegroups/write",
-              "Microsoft.Resources/subscriptions/resourcegroups/delete"
-            ]
-          }
-        ],
-        "assignableScopes": [
-          "[subscription().id]"
-        ]
-      }
     }
   ],
   "outputs": {
@@ -485,14 +377,6 @@
     "PrivateHttpAccess": {
       "type": "string",
       "value": "[format('http://{0}:{1}', reference(resourceId('Microsoft.Network/networkInterfaces', variables('networkInterfaceName')), '2021-05-01').ipConfigurations[0].properties.privateIPAddress, parameters('httpPort'))]"
-    },
-    "PublicGrpcAccess": {
-      "type": "string",
-      "value": "[format('http://{0}:{1}', reference(resourceId('Microsoft.Network/publicIPAddresses', variables('publicIPAddressName')), '2021-05-01').dnsSettings.fqdn, parameters('grpcPort'))]"
-    },
-    "PrivateGrpcAccess": {
-      "type": "string",
-      "value": "[format('http://{0}:{1}', reference(resourceId('Microsoft.Network/networkInterfaces', variables('networkInterfaceName')), '2021-05-01').ipConfigurations[0].properties.privateIPAddress, parameters('grpcPort'))]"
     },
     "SecurityGroup": {
       "type": "string",

--- a/deployments/jupyter/platform/azure/resource-manager-template/templates/cloudinit.yaml
+++ b/deployments/jupyter/platform/azure/resource-manager-template/templates/cloudinit.yaml
@@ -1,0 +1,13 @@
+#cloud-config
+write_files:
+- encoding: b64
+  content: "{0}"
+  owner: root:root
+  path: /usr/lib/systemd/system/jupyter.service
+  permissions: '0640'
+
+runcmd:
+- while [ $(systemctl status docker | grep "active (running)" | wc -l) -lt 1 ]; do sleep 5; done
+- sleep 60
+- systemctl enable jupyter.service
+- systemctl start jupyter.service

--- a/deployments/jupyter/platform/azure/resource-manager-template/templates/jupyter.service
+++ b/deployments/jupyter/platform/azure/resource-manager-template/templates/jupyter.service
@@ -1,0 +1,25 @@
+[Unit]
+Description=jupyter
+After=docker.service
+Requires=docker.service
+StartLimitInterval=200
+StartLimitBurst=10
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+RestartSec=2
+ExecStartPre=-/usr/bin/mkdir -p /etc/td
+ExecStartPre=-/usr/bin/docker exec %n stop || true
+ExecStartPre=-/usr/bin/docker rm %n || true
+ExecStartPre=/usr/bin/docker pull {0}/{1}:{2}
+
+ExecStart=/usr/bin/docker run \
+    -e accept_license=Y \
+    -e JUPYTER_TOKEN=${4} \
+    -v /etc/td:/home/jovyan/JupyterLabRoot/userdata \
+    -p {3}:8888 \
+    --rm --name %n {0}/{1}:{2}
+
+[Install]
+WantedBy=multi-user.target

--- a/deployments/jupyter/platform/azure/terraform/README.md
+++ b/deployments/jupyter/platform/azure/terraform/README.md
@@ -1,0 +1,76 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <=3.50.0 |
+| <a name="requirement_cloudinit"></a> [cloudinit](#requirement\_cloudinit) | <=2.2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | <=3.50.0 |
+| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | <=2.2.0 |
+| <a name="provider_random"></a> [random](#provider\_random) | n/a |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_network_interface.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface) | resource |
+| [azurerm_network_interface_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_security_group_association) | resource |
+| [azurerm_network_security_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group) | resource |
+| [azurerm_network_security_rule.http](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
+| [azurerm_network_security_rule.ssh](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
+| [azurerm_public_ip.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
+| [azurerm_virtual_machine.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine) | resource |
+| [azurerm_virtual_machine_extension.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_extension) | resource |
+| [random_uuid.jupyter_token](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/uuid) | resource |
+| [azurerm_client_config.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azurerm_platform_image.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/platform_image) | data source |
+| [azurerm_public_ip.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip) | data source |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+| [azurerm_ssh_public_key.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/ssh_public_key) | data source |
+| [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
+| [azurerm_subscription.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
+| [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
+| [cloudinit_config.this](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_access_cidrs"></a> [access\_cidrs](#input\_access\_cidrs) | n/a | `list(string)` | n/a | yes |
+| <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | n/a | `number` | `30` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | n/a | `string` | `"Standard_LRS"` | no |
+| <a name="input_egress_cidrs"></a> [egress\_cidrs](#input\_egress\_cidrs) | n/a | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_http_port"></a> [http\_port](#input\_http\_port) | n/a | `number` | `8888` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | n/a | `string` | `"Standard_B2s"` | no |
+| <a name="input_jupyter_name"></a> [jupyter\_name](#input\_jupyter\_name) | n/a | `string` | `"jupyter"` | no |
+| <a name="input_jupyter_registry"></a> [jupyter\_registry](#input\_jupyter\_registry) | n/a | `string` | `"teradata"` | no |
+| <a name="input_jupyter_repository"></a> [jupyter\_repository](#input\_jupyter\_repository) | n/a | `string` | `"regulus-jupyter"` | no |
+| <a name="input_jupyter_version"></a> [jupyter\_version](#input\_jupyter\_version) | n/a | `string` | `"latest"` | no |
+| <a name="input_key_name"></a> [key\_name](#input\_key\_name) | n/a | `string` | n/a | yes |
+| <a name="input_network_name"></a> [network\_name](#input\_network\_name) | n/a | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | n/a | `string` | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | n/a | `string` | n/a | yes |
+| <a name="input_ssh_enabled"></a> [ssh\_enabled](#input\_ssh\_enabled) | n/a | `bool` | `false` | no |
+| <a name="input_subnet_name"></a> [subnet\_name](#input\_subnet\_name) | n/a | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `{}` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_private_grpc_access"></a> [private\_grpc\_access](#output\_private\_grpc\_access) | n/a |
+| <a name="output_private_ip"></a> [private\_ip](#output\_private\_ip) | n/a |
+| <a name="output_public_http_access"></a> [public\_http\_access](#output\_public\_http\_access) | n/a |
+| <a name="output_public_ip"></a> [public\_ip](#output\_public\_ip) | n/a |
+| <a name="output_security_group"></a> [security\_group](#output\_security\_group) | n/a |
+| <a name="output_ssh_connection"></a> [ssh\_connection](#output\_ssh\_connection) | n/a |
+<!-- END_TF_DOCS -->

--- a/deployments/jupyter/platform/azure/terraform/data.tf
+++ b/deployments/jupyter/platform/azure/terraform/data.tf
@@ -1,0 +1,61 @@
+data "azurerm_client_config" "this" {}
+data "azurerm_subscription" "this" {}
+
+locals {
+  image_publisher = "Canonical"
+  image_offer     = "0001-com-ubuntu-server-jammy"
+  image_sku       = "22_04-lts-gen2"
+  ssh_enabled     = var.ssh_enabled ? "Allow" : "Deny"
+}
+
+data "azurerm_ssh_public_key" "this" {
+  name                = var.key_name
+  resource_group_name = data.azurerm_resource_group.this.name
+}
+
+data "azurerm_platform_image" "this" {
+  location  = data.azurerm_resource_group.this.location
+  publisher = local.image_publisher
+  offer     = local.image_offer
+  sku       = local.image_sku
+}
+
+data "azurerm_resource_group" "this" {
+  name = var.resource_group_name
+}
+
+data "azurerm_virtual_network" "this" {
+  name                = var.network_name
+  resource_group_name = data.azurerm_resource_group.this.name
+}
+
+data "azurerm_subnet" "this" {
+  name                 = var.subnet_name
+  virtual_network_name = data.azurerm_virtual_network.this.name
+  resource_group_name  = data.azurerm_resource_group.this.name
+}
+
+data "cloudinit_config" "this" {
+  gzip          = true
+  base64_encode = true
+
+  part {
+    content_type = "text/cloud-config"
+    content = templatefile("${path.module}/templates/cloudinit.yaml.tftpl", {
+      jupyter_service : base64encode(templatefile("${path.module}/templates/jupyter.service.tftpl", {
+        jupyter_registry : var.jupyter_registry
+        jupyter_repository : var.jupyter_repository
+        jupyter_version : var.jupyter_version
+        jupyter_token : random_uuid.jupyter_token.result
+        http_port : var.http_port
+      }))
+    })
+  }
+}
+
+data "azurerm_public_ip" "this" {
+  name                = azurerm_public_ip.this.name
+  resource_group_name = data.azurerm_resource_group.this.name
+  depends_on          = [azurerm_virtual_machine.this]
+}
+

--- a/deployments/jupyter/platform/azure/terraform/firewalls.tf
+++ b/deployments/jupyter/platform/azure/terraform/firewalls.tf
@@ -1,0 +1,36 @@
+resource "azurerm_network_security_group" "this" {
+  name                = join("-", [var.jupyter_name, "access"])
+  resource_group_name = data.azurerm_resource_group.this.name
+  location            = data.azurerm_resource_group.this.location
+  tags                = var.tags
+}
+
+resource "azurerm_network_security_rule" "ssh" {
+  name                         = "${local.ssh_enabled}_SSH"
+  description                  = "${local.ssh_enabled} SSH"
+  priority                     = 700
+  direction                    = "Inbound"
+  access                       = local.ssh_enabled
+  protocol                     = "Tcp"
+  source_port_range            = "*"
+  destination_port_range       = "22"
+  source_address_prefixes      = var.access_cidrs
+  destination_address_prefixes = var.egress_cidrs
+  resource_group_name          = data.azurerm_resource_group.this.name
+  network_security_group_name  = azurerm_network_security_group.this.name
+}
+
+resource "azurerm_network_security_rule" "http" {
+  name                         = "Allow_HTTP"
+  description                  = "Allow HTTP"
+  priority                     = 701
+  direction                    = "Inbound"
+  access                       = "Allow"
+  protocol                     = "Tcp"
+  source_port_range            = "*"
+  destination_port_range       = var.http_port
+  source_address_prefixes      = var.access_cidrs
+  destination_address_prefixes = var.egress_cidrs
+  resource_group_name          = data.azurerm_resource_group.this.name
+  network_security_group_name  = azurerm_network_security_group.this.name
+}

--- a/deployments/jupyter/platform/azure/terraform/main.tf
+++ b/deployments/jupyter/platform/azure/terraform/main.tf
@@ -1,0 +1,27 @@
+terraform {
+
+  # override at init if needed
+  backend "local" {}
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "<=3.50.0"
+    }
+    cloudinit = {
+      source  = "hashicorp/cloudinit"
+      version = "<=2.2.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    virtual_machine {
+      delete_os_disk_on_deletion = true
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+  }
+}

--- a/deployments/jupyter/platform/azure/terraform/network/network.tf
+++ b/deployments/jupyter/platform/azure/terraform/network/network.tf
@@ -1,0 +1,69 @@
+terraform {
+
+  # override at init if needed
+  backend "local" {}
+
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "<=3.50.0"
+    }
+    cloudinit = {
+      source  = "hashicorp/cloudinit"
+      version = "<=2.2.0"
+    }
+  }
+}
+
+provider "azurerm" {
+  features {
+    virtual_machine {
+      delete_os_disk_on_deletion = true
+    }
+    resource_group {
+      prevent_deletion_if_contains_resources = false
+    }
+    key_vault {
+      purge_soft_delete_on_destroy    = true
+      recover_soft_deleted_key_vaults = false
+    }
+  }
+}
+
+
+resource "azurerm_resource_group" "this" {
+  name     = var.resource_group_name
+  location = var.region
+}
+
+resource "azurerm_virtual_network" "this" {
+  name                = var.network_name
+  address_space       = [var.network_cidr]
+  location            = azurerm_resource_group.this.location
+  resource_group_name = azurerm_resource_group.this.name
+  lifecycle {
+    ignore_changes = [
+      tags["CreateDate"],
+      tags["Owner"]
+    ]
+  }
+}
+
+resource "azurerm_subnet" "this" {
+  name                 = var.subnet_name
+  resource_group_name  = azurerm_resource_group.this.name
+  virtual_network_name = azurerm_virtual_network.this.name
+  address_prefixes     = [var.subnet_cidr]
+}
+
+output "resource_group" {
+  value = azurerm_resource_group.this
+}
+
+output "network" {
+  value = azurerm_virtual_network.this
+}
+
+output "subnet" {
+  value = azurerm_subnet.this
+}

--- a/deployments/jupyter/platform/azure/terraform/network/terraform.tfvars
+++ b/deployments/jupyter/platform/azure/terraform/network/terraform.tfvars
@@ -1,0 +1,4 @@
+# resource_group_name = ""
+# region = ""
+# network_name = ""
+# subnet_name = ""

--- a/deployments/jupyter/platform/azure/terraform/network/variables.tf
+++ b/deployments/jupyter/platform/azure/terraform/network/variables.tf
@@ -1,0 +1,25 @@
+variable "resource_group_name" {
+  type = string
+}
+
+variable "region" {
+  type = string
+}
+
+variable "network_name" {
+  type = string
+}
+
+variable "subnet_name" {
+  type = string
+}
+
+variable "network_cidr" {
+  type    = string
+  default = "10.1.0.0/16"
+}
+
+variable "subnet_cidr" {
+  type    = string
+  default = "10.1.0.0/24"
+}

--- a/deployments/jupyter/platform/azure/terraform/outputs.tf
+++ b/deployments/jupyter/platform/azure/terraform/outputs.tf
@@ -1,0 +1,23 @@
+output "public_ip" {
+  value = data.azurerm_public_ip.this.ip_address
+}
+
+output "private_ip" {
+  value = azurerm_network_interface.this.private_ip_address
+}
+
+output "public_http_access" {
+  value = "http://${data.azurerm_public_ip.this.ip_address}:${var.http_port}?token=${random_uuid.jupyter_token.result}"
+}
+
+output "private_grpc_access" {
+  value = "http://${azurerm_network_interface.this.private_ip_address}:${var.http_port}?token=${random_uuid.jupyter_token.result}"
+}
+
+output "security_group" {
+  value = azurerm_network_security_group.this.id
+}
+
+output "ssh_connection" {
+  value = "ssh ec2-user@${data.azurerm_public_ip.this.ip_address}"
+}

--- a/deployments/jupyter/platform/azure/terraform/resources.tf
+++ b/deployments/jupyter/platform/azure/terraform/resources.tf
@@ -1,0 +1,106 @@
+resource "azurerm_public_ip" "this" {
+  name                = join("-", [var.jupyter_name, "public-ip"])
+  location            = data.azurerm_resource_group.this.location
+  resource_group_name = data.azurerm_resource_group.this.name
+  allocation_method   = "Dynamic"
+  lifecycle {
+    ignore_changes = [
+      tags["CreateDate"],
+      tags["Owner"]
+    ]
+  }
+}
+
+resource "azurerm_network_interface" "this" {
+  name                = join("-", [var.jupyter_name, "nic"])
+  location            = data.azurerm_resource_group.this.location
+  resource_group_name = data.azurerm_resource_group.this.name
+
+  ip_configuration {
+    name                          = join("-", [var.jupyter_name, "nic"])
+    subnet_id                     = data.azurerm_subnet.this.id
+    private_ip_address_allocation = "Dynamic"
+    public_ip_address_id          = azurerm_public_ip.this.id
+  }
+  lifecycle {
+    ignore_changes = [
+      tags["CreateDate"],
+      tags["Owner"]
+    ]
+  }
+}
+
+resource "azurerm_network_interface_security_group_association" "this" {
+  network_interface_id      = azurerm_network_interface.this.id
+  network_security_group_id = azurerm_network_security_group.this.id
+}
+
+resource "azurerm_virtual_machine" "this" {
+  name                  = var.jupyter_name
+  location              = data.azurerm_resource_group.this.location
+  resource_group_name   = data.azurerm_resource_group.this.name
+  network_interface_ids = [azurerm_network_interface.this.id]
+  vm_size               = var.instance_type
+
+  delete_os_disk_on_termination    = true
+  delete_data_disks_on_termination = true
+
+  storage_image_reference {
+    publisher = data.azurerm_platform_image.this.publisher
+    offer     = data.azurerm_platform_image.this.offer
+    sku       = data.azurerm_platform_image.this.sku
+    version   = data.azurerm_platform_image.this.version
+  }
+
+  storage_os_disk {
+    name              = join("-", [var.jupyter_name, "disk"])
+    caching           = "ReadWrite"
+    create_option     = "FromImage"
+    managed_disk_type = var.disk_type
+    disk_size_gb      = var.disk_size
+  }
+
+  identity {
+    type = "SystemAssigned"
+  }
+
+  os_profile {
+    computer_name  = var.jupyter_name
+    admin_username = "azureuser"
+    custom_data    = data.cloudinit_config.this.rendered
+  }
+
+  os_profile_linux_config {
+    disable_password_authentication = true
+    ssh_keys {
+      key_data = data.azurerm_ssh_public_key.this.public_key
+      path     = "/home/azureuser/.ssh/authorized_keys"
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [
+      os_profile,
+      tags["CreateDate"],
+      tags["Owner"]
+    ]
+  }
+
+  tags = var.tags
+
+  depends_on = [
+    azurerm_network_interface_security_group_association.this
+  ]
+}
+
+resource "azurerm_virtual_machine_extension" "this" {
+  name                       = join("-", [var.jupyter_name, "Docker", "Extension"])
+  virtual_machine_id         = azurerm_virtual_machine.this.id
+  publisher                  = "Microsoft.Azure.Extensions"
+  type                       = "DockerExtension"
+  type_handler_version       = "1.1"
+  auto_upgrade_minor_version = true
+  tags                       = var.tags
+}
+
+resource "random_uuid" "jupyter_token" {}

--- a/deployments/jupyter/platform/azure/terraform/templates/cloudinit.yaml.tftpl
+++ b/deployments/jupyter/platform/azure/terraform/templates/cloudinit.yaml.tftpl
@@ -1,0 +1,13 @@
+#cloud-config
+write_files:
+- encoding: b64
+  content: "${ jupyter_service }"
+  owner: root:root
+  path: /usr/lib/systemd/system/jupyter.service
+  permissions: '0640'
+
+runcmd:
+- while [ $(systemctl status docker | grep "active (running)" | wc -l) -lt 1 ]; do sleep 5; done
+- sleep 60
+- systemctl enable jupyter.service
+- systemctl start jupyter.service

--- a/deployments/jupyter/platform/azure/terraform/templates/jupyter.service.tftpl
+++ b/deployments/jupyter/platform/azure/terraform/templates/jupyter.service.tftpl
@@ -1,0 +1,25 @@
+[Unit]
+Description=jupyter
+After=docker.service
+Requires=docker.service
+StartLimitInterval=200
+StartLimitBurst=10
+
+[Service]
+TimeoutStartSec=0
+Restart=always
+RestartSec=2
+ExecStartPre=-/usr/bin/mkdir -p /etc/td
+ExecStartPre=-/usr/bin/docker exec %n stop || true
+ExecStartPre=-/usr/bin/docker rm %n || true
+ExecStartPre=/usr/bin/docker pull ${ jupyter_registry }/${ jupyter_repository }:${ jupyter_version }
+
+ExecStart=/usr/bin/docker run \
+    -e accept_license=Y \
+    -e JUPYTER_TOKEN=${ jupyter_token } \
+    -v /etc/td:/etc/td \
+    -p ${ http_port }:8888 \
+    --rm --name %n ${ jupyter_registry }/${ jupyter_repository }:${ jupyter_version }
+
+[Install]
+WantedBy=multi-user.target

--- a/deployments/jupyter/platform/azure/terraform/terraform.tfvars
+++ b/deployments/jupyter/platform/azure/terraform/terraform.tfvars
@@ -1,0 +1,7 @@
+# resource_group_name = ""
+# region = ""
+# network_name = ""
+# subnet_name = ""
+# key_name = ""
+# role_definition_name = ""
+

--- a/deployments/jupyter/platform/azure/terraform/variables.tf
+++ b/deployments/jupyter/platform/azure/terraform/variables.tf
@@ -1,0 +1,78 @@
+variable "region" {
+  type = string
+}
+
+variable "resource_group_name" {
+  type = string
+}
+
+variable "network_name" {
+  type = string
+}
+
+variable "subnet_name" {
+  type = string
+}
+
+variable "instance_type" {
+  type    = string
+  default = "Standard_B2s"
+}
+
+variable "key_name" {
+  type = string
+}
+
+variable "tags" {
+  type    = map(string)
+  default = {}
+}
+
+variable "jupyter_name" {
+  type    = string
+  default = "jupyter"
+}
+
+variable "jupyter_registry" {
+  type    = string
+  default = "teradata"
+}
+
+variable "jupyter_repository" {
+  type    = string
+  default = "regulus-jupyter"
+}
+
+variable "jupyter_version" {
+  type    = string
+  default = "latest"
+}
+
+variable "ssh_enabled" {
+  type    = bool
+  default = false
+}
+
+variable "access_cidrs" {
+  type    = list(string)
+}
+
+variable "egress_cidrs" {
+  type    = list(string)
+  default = ["0.0.0.0/0"]
+}
+
+variable "http_port" {
+  type    = number
+  default = 8888
+}
+
+variable "disk_type" {
+  type    = string
+  default = "Standard_LRS"
+}
+
+variable "disk_size" {
+  type    = number
+  default = 30
+}

--- a/deployments/workspaces/platform/aws/cloud-formation-template/workspaces.yaml
+++ b/deployments/workspaces/platform/aws/cloud-formation-template/workspaces.yaml
@@ -330,9 +330,18 @@ Outputs:
   PublicIP:
     Description: EC2 public IP
     Value: !GetAtt WorkspacesServer.PublicIp
-  WebsiteURL:
+  PrivateIP:
+    Description: EC2 private IP
+    Value: !GetAtt WorkspacesServer.PrivateIp
+  PublicHttpAccess:
     Description: Teradata Workspaces Server
     Value: !Sub "http://${WorkspacesServer.PublicDnsName}:${ HttpPort }"
+  PrivateHttpAccess:
+    Description: Teradata Workspaces Server
+    Value: !Sub "http://${WorkspacesServer.PrivateDnsName}:${ HttpPort }"
   SecurityGroup:
     Description: Workspaces Security Group
     Value: !GetAtt WorkspacesSecurityGroup.GroupId
+  SSHConeection:
+    Description: Workspaces ssh connnection string
+    Value: !Sub "ssh ec2-user@${ WorkspacesServer.PublicIp }"

--- a/deployments/workspaces/platform/aws/terraform/README.md
+++ b/deployments/workspaces/platform/aws/terraform/README.md
@@ -39,7 +39,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_access_cidrs"></a> [access\_cidrs](#input\_access\_cidrs) | n/a | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | <a name="input_access_security_groups"></a> [access\_security\_groups](#input\_access\_security\_groups) | n/a | `list(string)` | `[]` | no |
-| <a name="input_egress_cidr"></a> [egress\_cidr](#input\_egress\_cidr) | n/a | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_egress_cidrs"></a> [egress\_cidrs](#input\_egress\_cidrs) | n/a | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
 | <a name="input_grpc_port"></a> [grpc\_port](#input\_grpc\_port) | n/a | `number` | `3282` | no |
 | <a name="input_http_port"></a> [http\_port](#input\_http\_port) | n/a | `number` | `3000` | no |
 | <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | n/a | `string` | `"t3.large"` | no |

--- a/deployments/workspaces/platform/aws/terraform/README.md
+++ b/deployments/workspaces/platform/aws/terraform/README.md
@@ -1,0 +1,69 @@
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | ~> 4.36.1 |
+| <a name="requirement_cloudinit"></a> [cloudinit](#requirement\_cloudinit) | ~> 2.2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | ~> 4.36.1 |
+| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | ~> 2.2.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_instance_profile.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_instance_profile) | resource |
+| [aws_iam_role.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role_policy.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role_policy) | resource |
+| [aws_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/instance) | resource |
+| [aws_launch_template.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/launch_template) | resource |
+| [aws_security_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group) | resource |
+| [aws_ami.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/ami) | data source |
+| [aws_iam_policy_document.instance-assume-role-policy](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_iam_policy_document.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_subnet.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/subnet) | data source |
+| [cloudinit_config.this](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_access_cidrs"></a> [access\_cidrs](#input\_access\_cidrs) | n/a | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_access_security_groups"></a> [access\_security\_groups](#input\_access\_security\_groups) | n/a | `list(string)` | `[]` | no |
+| <a name="input_egress_cidr"></a> [egress\_cidr](#input\_egress\_cidr) | n/a | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_grpc_port"></a> [grpc\_port](#input\_grpc\_port) | n/a | `number` | `3282` | no |
+| <a name="input_http_port"></a> [http\_port](#input\_http\_port) | n/a | `number` | `3000` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | n/a | `string` | `"t3.large"` | no |
+| <a name="input_key_name"></a> [key\_name](#input\_key\_name) | name of existing ssh key to enable access to workspaces server | `string` | `null` | no |
+| <a name="input_monitoring_enabled"></a> [monitoring\_enabled](#input\_monitoring\_enabled) | n/a | `bool` | `false` | no |
+| <a name="input_region"></a> [region](#input\_region) | n/a | `string` | n/a | yes |
+| <a name="input_subnet_id"></a> [subnet\_id](#input\_subnet\_id) | n/a | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `{}` | no |
+| <a name="input_termination_protection"></a> [termination\_protection](#input\_termination\_protection) | n/a | `bool` | `false` | no |
+| <a name="input_volume_size"></a> [volume\_size](#input\_volume\_size) | n/a | `number` | `20` | no |
+| <a name="input_workspaces_name"></a> [workspaces\_name](#input\_workspaces\_name) | n/a | `string` | `"workspaces"` | no |
+| <a name="input_workspaces_registry"></a> [workspaces\_registry](#input\_workspaces\_registry) | n/a | `string` | `"teradata"` | no |
+| <a name="input_workspaces_repository"></a> [workspaces\_repository](#input\_workspaces\_repository) | n/a | `string` | `"regulus-workspaces"` | no |
+| <a name="input_workspaces_version"></a> [workspaces\_version](#input\_workspaces\_version) | n/a | `string` | `"latest"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_private_grpc_access_workspaces"></a> [private\_grpc\_access\_workspaces](#output\_private\_grpc\_access\_workspaces) | n/a |
+| <a name="output_private_http_access_workspaces"></a> [private\_http\_access\_workspaces](#output\_private\_http\_access\_workspaces) | n/a |
+| <a name="output_private_ip_workspaces"></a> [private\_ip\_workspaces](#output\_private\_ip\_workspaces) | n/a |
+| <a name="output_public_grpc_access_workspaces"></a> [public\_grpc\_access\_workspaces](#output\_public\_grpc\_access\_workspaces) | n/a |
+| <a name="output_public_http_access_workspaces"></a> [public\_http\_access\_workspaces](#output\_public\_http\_access\_workspaces) | n/a |
+| <a name="output_public_ip_workspaces"></a> [public\_ip\_workspaces](#output\_public\_ip\_workspaces) | n/a |
+| <a name="output_security_group"></a> [security\_group](#output\_security\_group) | n/a |
+<!-- END_TF_DOCS -->

--- a/deployments/workspaces/platform/aws/terraform/outputs.tf
+++ b/deployments/workspaces/platform/aws/terraform/outputs.tf
@@ -1,9 +1,25 @@
-output "public_ip" {
+output "public_ip_workspaces" {
   value = aws_instance.this.public_ip
 }
 
-output "website_url" {
+output "private_ip_workspaces" {
+  value = aws_instance.this.private_ip
+}
+
+output "private_http_access_workspaces" {
+  value = "http://${aws_instance.this.private_ip}:${var.http_port}"
+}
+
+output "public_http_access_workspaces" {
   value = "http://${aws_instance.this.public_dns}:${var.http_port}"
+}
+
+output "private_grpc_access_workspaces" {
+  value = "${aws_instance.this.private_ip}:${var.grpc_port}"
+}
+
+output "public_grpc_access_workspaces" {
+  value = "${aws_instance.this.public_dns}:${var.grpc_port}"
 }
 
 output "security_group" {

--- a/deployments/workspaces/platform/azure/terraform/README.md
+++ b/deployments/workspaces/platform/azure/terraform/README.md
@@ -118,3 +118,84 @@ resource "azurerm_role_assignment" "this" {
 #   role_definition_name = azurerm_role_definition.this.name
 #   principal_id         = azurerm_virtual_machine.this.identity.0.principal_id
 # }
+<!-- BEGIN_TF_DOCS -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_azurerm"></a> [azurerm](#requirement\_azurerm) | <=3.50.0 |
+| <a name="requirement_cloudinit"></a> [cloudinit](#requirement\_cloudinit) | <=2.2.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_azurerm"></a> [azurerm](#provider\_azurerm) | <=3.50.0 |
+| <a name="provider_cloudinit"></a> [cloudinit](#provider\_cloudinit) | <=2.2.0 |
+
+## Modules
+
+No modules.
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [azurerm_network_interface.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface) | resource |
+| [azurerm_network_interface_security_group_association.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_interface_security_group_association) | resource |
+| [azurerm_network_security_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_group) | resource |
+| [azurerm_network_security_rule.grpc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
+| [azurerm_network_security_rule.http](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
+| [azurerm_network_security_rule.ssh](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/network_security_rule) | resource |
+| [azurerm_public_ip.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/public_ip) | resource |
+| [azurerm_role_assignment.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_assignment) | resource |
+| [azurerm_role_definition.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/role_definition) | resource |
+| [azurerm_virtual_machine.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine) | resource |
+| [azurerm_virtual_machine_extension.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/virtual_machine_extension) | resource |
+| [azurerm_client_config.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/client_config) | data source |
+| [azurerm_platform_image.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/platform_image) | data source |
+| [azurerm_public_ip.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/public_ip) | data source |
+| [azurerm_resource_group.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/resource_group) | data source |
+| [azurerm_ssh_public_key.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/ssh_public_key) | data source |
+| [azurerm_subnet.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subnet) | data source |
+| [azurerm_subscription.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/subscription) | data source |
+| [azurerm_virtual_network.this](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/data-sources/virtual_network) | data source |
+| [cloudinit_config.this](https://registry.terraform.io/providers/hashicorp/cloudinit/latest/docs/data-sources/config) | data source |
+
+## Inputs
+
+| Name | Description | Type | Default | Required |
+|------|-------------|------|---------|:--------:|
+| <a name="input_access_cidrs"></a> [access\_cidrs](#input\_access\_cidrs) | n/a | `list(string)` | n/a | yes |
+| <a name="input_disk_size"></a> [disk\_size](#input\_disk\_size) | n/a | `number` | `30` | no |
+| <a name="input_disk_type"></a> [disk\_type](#input\_disk\_type) | n/a | `string` | `"Standard_LRS"` | no |
+| <a name="input_egress_cidrs"></a> [egress\_cidrs](#input\_egress\_cidrs) | n/a | `list(string)` | <pre>[<br>  "0.0.0.0/0"<br>]</pre> | no |
+| <a name="input_grpc_port"></a> [grpc\_port](#input\_grpc\_port) | n/a | `number` | `3282` | no |
+| <a name="input_http_port"></a> [http\_port](#input\_http\_port) | n/a | `number` | `3000` | no |
+| <a name="input_instance_type"></a> [instance\_type](#input\_instance\_type) | n/a | `string` | `"Standard_B2s"` | no |
+| <a name="input_key_name"></a> [key\_name](#input\_key\_name) | n/a | `string` | n/a | yes |
+| <a name="input_network_name"></a> [network\_name](#input\_network\_name) | n/a | `string` | n/a | yes |
+| <a name="input_region"></a> [region](#input\_region) | n/a | `string` | n/a | yes |
+| <a name="input_resource_group_name"></a> [resource\_group\_name](#input\_resource\_group\_name) | n/a | `string` | n/a | yes |
+| <a name="input_role_definition_name"></a> [role\_definition\_name](#input\_role\_definition\_name) | n/a | `string` | `null` | no |
+| <a name="input_ssh_enabled"></a> [ssh\_enabled](#input\_ssh\_enabled) | n/a | `bool` | `false` | no |
+| <a name="input_subnet_name"></a> [subnet\_name](#input\_subnet\_name) | n/a | `string` | n/a | yes |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `{}` | no |
+| <a name="input_workspaces_name"></a> [workspaces\_name](#input\_workspaces\_name) | n/a | `string` | `"workspaces"` | no |
+| <a name="input_workspaces_registry"></a> [workspaces\_registry](#input\_workspaces\_registry) | n/a | `string` | `"teradata"` | no |
+| <a name="input_workspaces_repository"></a> [workspaces\_repository](#input\_workspaces\_repository) | n/a | `string` | `"regulus-workspaces"` | no |
+| <a name="input_workspaces_version"></a> [workspaces\_version](#input\_workspaces\_version) | n/a | `string` | `"latest"` | no |
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_private_grpc_access_workspaces"></a> [private\_grpc\_access\_workspaces](#output\_private\_grpc\_access\_workspaces) | n/a |
+| <a name="output_private_http_access_workspaces"></a> [private\_http\_access\_workspaces](#output\_private\_http\_access\_workspaces) | n/a |
+| <a name="output_private_ip_workspaces"></a> [private\_ip\_workspaces](#output\_private\_ip\_workspaces) | n/a |
+| <a name="output_public_grpc_access_workspaces"></a> [public\_grpc\_access\_workspaces](#output\_public\_grpc\_access\_workspaces) | n/a |
+| <a name="output_public_http_access_workspaces"></a> [public\_http\_access\_workspaces](#output\_public\_http\_access\_workspaces) | n/a |
+| <a name="output_public_ip_workspaces"></a> [public\_ip\_workspaces](#output\_public\_ip\_workspaces) | n/a |
+| <a name="output_security_group"></a> [security\_group](#output\_security\_group) | n/a |
+| <a name="output_ssh_connection"></a> [ssh\_connection](#output\_ssh\_connection) | n/a |
+<!-- END_TF_DOCS -->

--- a/deployments/workspaces/platform/azure/terraform/network/terraform.tfvars
+++ b/deployments/workspaces/platform/azure/terraform/network/terraform.tfvars
@@ -2,3 +2,7 @@
 # region = ""
 # network_name = ""
 # subnet_name = ""
+resource_group_name = "ws-az-tf-test"
+region = "West US"
+network_name = "ws-az-tf-test"
+subnet_name = "ws-az-tf-test"

--- a/deployments/workspaces/platform/azure/terraform/outputs.tf
+++ b/deployments/workspaces/platform/azure/terraform/outputs.tf
@@ -1,3 +1,32 @@
-output "public_ips_master" {
+output "public_ip_workspaces" {
   value = data.azurerm_public_ip.this.ip_address
+}
+
+output "private_ip_workspaces" {
+  value = azurerm_network_interface.this.private_ip_address
+}
+
+output "private_http_access_workspaces" {
+  value = "http://${azurerm_network_interface.this.private_ip_address}:${var.http_port}"
+}
+
+output "public_http_access_workspaces" {
+  value = "http://${data.azurerm_public_ip.this.ip_address}:${var.http_port}"
+}
+
+output "private_grpc_access_workspaces" {
+  value = "${azurerm_network_interface.this.private_ip_address}:${var.grpc_port}"
+}
+
+output "public_grpc_access_workspaces" {
+  value = "${data.azurerm_public_ip.this.ip_address}:${var.grpc_port}"
+}
+
+output "security_group" {
+  value = azurerm_network_security_group.this.id
+}
+
+
+output "ssh_connection" {
+  value = "ssh azureuser@${data.azurerm_public_ip.this.ip_address}"
 }

--- a/deployments/workspaces/platform/docker/compose/docker-compose.yaml
+++ b/deployments/workspaces/platform/docker/compose/docker-compose.yaml
@@ -4,15 +4,17 @@ services:
   workspaces:
     deploy:
       replicas: 1
+    platform: linux/amd64
     container_name: workspaces
-    image: ${WORKSPACES_IMAGE_NAME:-ghcr.io/teradata-tio/workspaces}:${WORKSPACES_IMAGE_TAG:-latest}
-    command: serve -v
+    image: ${WORKSPACES_IMAGE_NAME:-teradata/regulus-workspaces}:${WORKSPACES_IMAGE_TAG:-latest}
+    command: workspaces serve -v
     restart: unless-stopped
     ports:
       - "443:443/tcp"
       - "3000:3000/tcp"
       - "3282:3282/tcp"
     environment:
+      accept_license: "Y"
       TZ: ${WS_TZ:-UTC}
       AWS_ACCESS_KEY_ID: "${AWS_ACCESS_KEY_ID}"
       AWS_SECRET_ACCESS_KEY: "${AWS_SECRET_ACCESS_KEY}"
@@ -20,12 +22,14 @@ services:
     volumes:
       - ${WORKSPACES_HOME:-./volumes/workspaces}:/etc/td
       - ${WORKSPACES_AWS_CONFIG:-~/.aws}:/root/.aws
+      # - ${WS_HOME:-~/.azure:/root/.azure
   jupyter:
     deploy:
       replicas: 0
-    image: ${JUPYTER_IMAGE_NAME:-ghcr.io/teradata-tio/compute-engine-jupyter-kernel}:${JUPYTER_IMAGE_TAG:-latest}
+    platform: linux/amd64
+    image: ${JUPYTER_IMAGE_NAME:-teradata/regulus-jupyter}:${JUPYTER_IMAGE_TAG:-latest}
     environment:
-      - "accept_license=Y"
+      accept_license: "Y"
     ports:
       - 8888:8888
     volumes:

--- a/deployments/workspaces/platform/kubernetes/native/manifest/jupyter.yaml
+++ b/deployments/workspaces/platform/kubernetes/native/manifest/jupyter.yaml
@@ -1,0 +1,59 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: regulus-jupyter
+  labels:
+    app: regulus-jupyter
+spec:
+  ports:
+    - port: 8888
+  selector:
+    app: regulus-jupyter
+    tier: jupyter
+  clusterIP: None
+---
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: regulus-jupyter-pv-claim
+  labels:
+    app: regulus-jupyter
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 20Gi
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: regulus-jupyter
+  labels:
+    app: regulus-jupyter
+spec:
+  selector:
+    matchLabels:
+      app: regulus-jupyter
+      tier: jupyter
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app: regulus-jupyter
+        tier: jupyter
+    spec:
+      containers:
+      - image: regulus-jupyter:latest
+        name: regulus-jupyter
+        ports:
+        - containerPort: 8888
+          name: jupyter
+        volumeMounts:
+        - name: regulus-jupyter-persistent-storage
+          mountPath: /home/jovyan/JupyterLabRoot/userdata
+      volumes:
+      - name: regulus-jupyter-persistent-storage
+        persistentVolumeClaim:
+          claimName: regulus-jupyter-pv-claim


### PR DESCRIPTION
Adds the first of the Jupyter client deploys to aws via Terraform.
Uses the same setup as workspaces, i.e. it just runs the Jupyter container via systemd and installs on a default Azure image.

The instance takes some time to set up as the Jupyter Container is rather large, and it displays the auth token in the terraform output. As such, it should be treated as a demo or ephemeral environment, not a hardened enterprise service