### PR TITLE
allow deploy in network without public IPs [AWS] [CFT]

### DIFF
--- a/deployments/jupyter/platform/aws/cloud-formation-template/jupyter.yaml
+++ b/deployments/jupyter/platform/aws/cloud-formation-template/jupyter.yaml
@@ -1,4 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
+
 Metadata:
   License: TODO
   AWS::CloudFormation::Interface:
@@ -14,6 +15,7 @@ Metadata:
       - Label:
           default: "jupyter connection"
         Parameters:
+          - Vpc
           - Subnet
           - KeyName
           - AccessCIDR
@@ -35,6 +37,11 @@ Parameters:
     MaxLength: '32'
     MinLength: '1'
     Type: String
+
+  Vpc:
+    ConstraintDescription: must be the name of an existing vpc.
+    Description: Network to deploy the jupyter service to.
+    Type: AWS::EC2::VPC::Id
 
   Subnet:
     ConstraintDescription: must be the name of an existing subnet.
@@ -121,18 +128,40 @@ Parameters:
     Type: String
 
   KeyName:
-    ConstraintDescription: must be the name of an existing EC2 KeyPair.
-    Description: Name of an existing EC2 KeyPair to enable SSH access to the instances
-    Type: AWS::EC2::KeyPair::KeyName
+    Description: Name of an existing EC2 KeyPair to enable SSH access to the instances, leave empty if no ssh keys should be included
+    Type: String
 
   AccessCIDR:
     AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\/(\d{1,2})
     ConstraintDescription: must be a valid IP CIDR range of the form x.x.x.x/x.
     Default: 0.0.0.0/0
-    Description: The IP address range that can be used to communicate with the jupyter instance.
+    Description: The IP address range that can be used to communicate with the workspaces instance.
     MaxLength: '18'
     MinLength: '9'
     Type: String
+
+Rules:
+  subnetInVpc:
+    Assertions:
+      - Assert:
+          Fn::EachMemberEquals:
+            - Fn::ValueOfAll:
+              - AWS::EC2::Subnet::Id
+              - VpcId
+            - Ref: Vpc
+        AssertDescription: The subnet you selected is not in the VPC
+
+Conditions:
+
+  HASKEY:
+    !Not [ !Equals [ !Ref KeyName, '' ] ]
+
+  HASCIDR:
+    !Not [ !Equals [!Ref AccessCIDR, '' ] ]
+
+  HASKEYANDCIDR: !And
+    - !Condition HASKEY
+    - !Condition HASCIDR
 
 Resources:
 
@@ -198,6 +227,7 @@ Resources:
                 enabled: "true"
                 ensureRunning: "true"
     Properties:
+      PropagateTagsToVolumeOnCreation: true
       BlockDeviceMappings:
         - DeviceName: /dev/xvda
           Ebs:
@@ -206,7 +236,11 @@ Resources:
       SubnetId: !Ref Subnet
       ImageId: !Ref LatestAmiId
       InstanceType: !Ref InstanceType
-      KeyName: !Ref KeyName
+      KeyName:
+        Fn::If:
+        - HASKEY
+        - Ref: KeyName
+        - Ref: AWS::NoValue
       DisableApiTermination: !Ref TerminationProtection
       SecurityGroupIds: [!GetAtt jupyterSecurityGroup.GroupId] 
       UserData:
@@ -218,18 +252,26 @@ Resources:
            /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource jupyterServer --region ${AWS::Region}
 
   jupyterSecurityGroup:
+    Condition: HASCIDR
     Type: AWS::EC2::SecurityGroup
     Properties:
+      VpcId: !Ref Vpc
       GroupDescription: "Enable access to jupyter server over http, grpc, and ssh"
       SecurityGroupIngress:
-      - CidrIp: !Ref AccessCIDR
-        FromPort: !Ref HttpPort
-        IpProtocol: tcp
-        ToPort: !Ref HttpPort
-      - CidrIp: !Ref AccessCIDR
-        FromPort: 22
-        IpProtocol: tcp
-        ToPort: 22
+        - CidrIp: !Ref AccessCIDR
+          FromPort: !Ref HttpPort
+          IpProtocol: tcp
+          ToPort: !Ref HttpPort
+      
+  SecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: HASKEYANDCIDR
+    Properties: 
+      GroupId: !GetAtt jupyterSecurityGroup.GroupId
+      CidrIp: !Ref AccessCIDR
+      FromPort: 22
+      IpProtocol: tcp
+      ToPort: 22
 
 Outputs:
   PublicIP:

--- a/deployments/jupyter/platform/aws/cloud-formation-template/jupyter.yaml
+++ b/deployments/jupyter/platform/aws/cloud-formation-template/jupyter.yaml
@@ -15,6 +15,7 @@ Metadata:
       - Label:
           default: "jupyter connection"
         Parameters:
+          - Private
           - Vpc
           - Subnet
           - KeyName
@@ -37,6 +38,14 @@ Parameters:
     MaxLength: '32'
     MinLength: '1'
     Type: String
+
+  Private:
+    Description: Will Jupyter be deployed in a private netowrk without public IPs?
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
 
   Vpc:
     ConstraintDescription: must be the name of an existing vpc.
@@ -153,6 +162,9 @@ Rules:
 
 Conditions:
 
+  HASPUBLICIP:
+    !Not [ !Equals [ !Ref Private, 'true' ] ]
+
   HASKEY:
     !Not [ !Equals [ !Ref KeyName, '' ] ]
 
@@ -162,6 +174,10 @@ Conditions:
   HASKEYANDCIDR: !And
     - !Condition HASKEY
     - !Condition HASCIDR
+
+  HASKEYANDPUBLIC: !And
+    - !Condition HASKEY
+    - !Condition HASPUBLICIP
 
 Resources:
 
@@ -275,20 +291,33 @@ Resources:
 
 Outputs:
   PublicIP:
+    Condition: HASPUBLICIP 
     Description: EC2 public IP
     Value: !GetAtt jupyterServer.PublicIp
+
   PrivateIP:
     Description: EC2 private IP
     Value: !GetAtt jupyterServer.PrivateIp
+
   PublicHttpAccess:
+    Condition: HASPUBLICIP 
     Description: Teradata jupyter Server
     Value: !Sub "http://${jupyterServer.PublicDnsName}:${ HttpPort }?token=${ JupyterToken }"
+
   PrivateHttpAccess:
     Description: Teradata jupyter Server
     Value: !Sub "http://${jupyterServer.PrivateDnsName}:${ HttpPort }?token=${ JupyterToken }"
+
   SecurityGroup:
     Description: jupyter Security Group
     Value: !GetAtt jupyterSecurityGroup.GroupId
-  SSHConeection:
+
+  PublicSSHConeection:
+    Condition: HASKEYANDPUBLIC
     Description: jupyter ssh connnection string
     Value: !Sub "ssh ec2-user@${ jupyterServer.PublicIp }"
+
+  PrivateSSHConeection:
+    Condition: HASKEY
+    Description: jupyter ssh connnection string
+    Value: !Sub "ssh ec2-user@${ jupyterServer.PrivateIp }"

--- a/deployments/workspaces/platform/aws/cloud-formation-template/workspaces.yaml
+++ b/deployments/workspaces/platform/aws/cloud-formation-template/workspaces.yaml
@@ -1,4 +1,5 @@
 AWSTemplateFormatVersion: '2010-09-09'
+
 Metadata:
   License: TODO
   AWS::CloudFormation::Interface:
@@ -13,6 +14,7 @@ Metadata:
       - Label:
           default: "Workspaces connection"
         Parameters:
+          - Vpc
           - Subnet
           - KeyName
           - AccessCIDR
@@ -37,9 +39,14 @@ Parameters:
     MinLength: '1'
     Type: String
 
+  Vpc:
+    ConstraintDescription: must be the name of an existing vpc.
+    Description: Network to deploy the jupyter service to.
+    Type: AWS::EC2::VPC::Id
+
   Subnet:
     ConstraintDescription: must be the name of an existing subnet.
-    Description: Subnetwork to deploy the workspaces service to.
+    Description: Subnetwork to deploy the jupyter service to.
     Type: AWS::EC2::Subnet::Id
 
   HttpPort:
@@ -125,9 +132,8 @@ Parameters:
     Type: String
 
   KeyName:
-    ConstraintDescription: must be the name of an existing EC2 KeyPair.
-    Description: Name of an existing EC2 KeyPair to enable SSH access to the instances
-    Type: AWS::EC2::KeyPair::KeyName
+    Description: Name of an existing EC2 KeyPair to enable SSH access to the instances, leave empty if no ssh keys should be included
+    Type: String
 
   AccessCIDR:
     AllowedPattern: (\d{1,3})\.(\d{1,3})\.(\d{1,3})\.(\d{1,3})\/(\d{1,2})
@@ -137,6 +143,29 @@ Parameters:
     MaxLength: '18'
     MinLength: '9'
     Type: String
+
+Rules:
+  subnetInVpc:
+    Assertions:
+      - Assert:
+          Fn::EachMemberEquals:
+            - Fn::ValueOfAll:
+              - AWS::EC2::Subnet::Id
+              - VpcId
+            - Ref: Vpc
+        AssertDescription: The subnet you selected is not in the VPC
+
+Conditions:
+
+  HASKEY:
+    !Not [ !Equals [ !Ref KeyName, '' ] ]
+
+  HASCIDR:
+    !Not [ !Equals [!Ref AccessCIDR, '' ] ]
+
+  HASKEYANDCIDR: !And
+    - !Condition HASKEY
+    - !Condition HASCIDR
 
 Resources:
 
@@ -203,6 +232,7 @@ Resources:
                 enabled: "true"
                 ensureRunning: "true"
     Properties:
+      PropagateTagsToVolumeOnCreation: true
       BlockDeviceMappings:
         - DeviceName: /dev/xvda
           Ebs:
@@ -211,7 +241,11 @@ Resources:
       SubnetId: !Ref Subnet
       ImageId: !Ref LatestAmiId
       InstanceType: !Ref InstanceType
-      KeyName: !Ref KeyName
+      KeyName:
+        Fn::If:
+        - HASKEY
+        - Ref: KeyName
+        - Ref: AWS::NoValue
       DisableApiTermination: !Ref TerminationProtection
       SecurityGroupIds: [!GetAtt WorkspacesSecurityGroup.GroupId] 
       IamInstanceProfile: !Ref WorkspacesInstanceProfile
@@ -224,8 +258,10 @@ Resources:
            /opt/aws/bin/cfn-signal -e $? --stack ${AWS::StackId} --resource WorkspacesServer --region ${AWS::Region}
 
   WorkspacesSecurityGroup:
+    Condition: HASCIDR
     Type: AWS::EC2::SecurityGroup
     Properties:
+      VpcId: !Ref Vpc
       GroupDescription: "Enable access to workspaces server over http, grpc, and ssh"
       SecurityGroupIngress:
       - CidrIp: !Ref AccessCIDR
@@ -236,10 +272,16 @@ Resources:
         FromPort: !Ref GrpcPort
         IpProtocol: tcp
         ToPort: !Ref GrpcPort
-      - CidrIp: !Ref AccessCIDR
-        FromPort: 22
-        IpProtocol: tcp
-        ToPort: 22
+
+  SecurityGroupIngress:
+    Type: AWS::EC2::SecurityGroupIngress
+    Condition: HASKEYANDCIDR
+    Properties: 
+      GroupId: !GetAtt WorkspacesSecurityGroup.GroupId
+      CidrIp: !Ref AccessCIDR
+      FromPort: 22
+      IpProtocol: tcp
+      ToPort: 22
 
   WorkspacesRole:
     Type: AWS::IAM::Role

--- a/deployments/workspaces/platform/aws/cloud-formation-template/workspaces.yaml
+++ b/deployments/workspaces/platform/aws/cloud-formation-template/workspaces.yaml
@@ -14,6 +14,7 @@ Metadata:
       - Label:
           default: "Workspaces connection"
         Parameters:
+          - Private
           - Vpc
           - Subnet
           - KeyName
@@ -38,6 +39,14 @@ Parameters:
     MaxLength: '32'
     MinLength: '1'
     Type: String
+
+  Private:
+    Description: Will Jupyter be deployed in a private netowrk without public IPs?
+    Type: String
+    Default: false
+    AllowedValues:
+      - true
+      - false
 
   Vpc:
     ConstraintDescription: must be the name of an existing vpc.
@@ -156,6 +165,9 @@ Rules:
         AssertDescription: The subnet you selected is not in the VPC
 
 Conditions:
+
+  HASPUBLICIP:
+    !Not [ !Equals [ !Ref Private, 'true' ] ]
 
   HASKEY:
     !Not [ !Equals [ !Ref KeyName, '' ] ]
@@ -370,20 +382,33 @@ Resources:
 
 Outputs:
   PublicIP:
+    Condition: HASPUBLICIP 
     Description: EC2 public IP
     Value: !GetAtt WorkspacesServer.PublicIp
+
   PrivateIP:
     Description: EC2 private IP
     Value: !GetAtt WorkspacesServer.PrivateIp
+
   PublicHttpAccess:
+    Condition: HASPUBLICIP 
     Description: Teradata Workspaces Server
-    Value: !Sub "http://${WorkspacesServer.PublicDnsName}:${ HttpPort }"
+    Value: !Sub "http://${WorkspacesServer.PublicDnsName}:${ HttpPort }?token=${ JupyterToken }"
+
   PrivateHttpAccess:
     Description: Teradata Workspaces Server
-    Value: !Sub "http://${WorkspacesServer.PrivateDnsName}:${ HttpPort }"
+    Value: !Sub "http://${WorkspacesServer.PrivateDnsName}:${ HttpPort }?token=${ JupyterToken }"
+
   SecurityGroup:
     Description: Workspaces Security Group
-    Value: !GetAtt WorkspacesSecurityGroup.GroupId
-  SSHConeection:
+    Value: !GetAtt WorkspacesServer.GroupId
+
+  PublicSSHConeection:
+    Condition: HASKEYANDPUBLIC
     Description: Workspaces ssh connnection string
     Value: !Sub "ssh ec2-user@${ WorkspacesServer.PublicIp }"
+
+  PrivateSSHConeection:
+    Condition: HASKEY
+    Description: Workspaces ssh connnection string
+    Value: !Sub "ssh ec2-user@${ WorkspacesServer.PrivateIp }"


### PR DESCRIPTION
Removes public IP outputs if private selected
Note we are not attaching public IPs and rely on the vpc/subnet to be configured to do that automatically.
If the network does not have public IPs, this change allows cloudforamtions to finish without failing.

Note: PR stacked on previous PR to simplify files changed view, but will merge to the develop branch in order